### PR TITLE
PFP-7473 FPLOS: Tilpasninger for å utvikler på egen laptop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ application-local.properties
 allure-results/*
 *-result.json
 server/src/main/resources/webapps
+resources/ssl-terminator/localhost.*

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Koble foreldrepenger til VTP
 
 *Ved å starte FPSAK med '--vtp' setter du følgende endepunkter:*
 
-
 * Aktoer_v2.url=https://localhost:8063/aktoerregister/ws/Aktoer/v2
 * Person_v3.url=https://localhost:8063/tpsws/ws/Person/v3
 * Journal_v2.url=https://localhost:8063/joark/Journal/v2
@@ -62,16 +61,21 @@ I tillegg, for å overstyre sikkerhet (PDP, STS, OpenAM):
 * oidc_sts.jwks.url=https://localhost:8063/sts/jwks
 
 ### STS web service
-* securityTokenService.url=https://localhost:8063/SecurityTokenServiceProvider/
+* securityTokenService.url=https://localhost:8063/soap/SecurityTokenServiceProvider/
 
 ### LDAP
 * ldap.url=ldaps://localhost:8636/
 * ldap.auth=none
 * ldap.user.basedn=ou\=NAV,ou\=BusinessUnits,dc\=test,dc\=local
 
-* OpenIdConnect.issoHost=https://localhost:8063/isso/oauth2
-* OpenIdConnect.issoIssuer=https://localhost:8063/isso/oauth2
-* OpenIdConnect.issoJwks=https://localhost:8063/isso/oauth2/connect/jwk_uri
+For å sjekke om LDAP kjører riktig kan man bruke `ldapsearch`, eksempel fra under.
+```bash
+ldapsearch -x -h localhost:8389 -b "ou=NAV,ou=BusinessUnits,dc=test,dc=local"
+```
+
+* OpenIdConnect.issoHost=https://localhost:8063/rest/isso/oauth2
+* OpenIdConnect.issoIssuer=https://localhost:8063/rest/isso/oauth2
+* OpenIdConnect.issoJwks=https://localhost:8063/rest/isso/oauth2/connect/jwk_uri
 * OpenIdConnect.username=fpsak-localhost
 
 * systembruker.username=vtp
@@ -100,3 +104,7 @@ LDAP_PROVIDER_URL=ldaps://fpmock2:8636
 AUTHORIZE_BASE_URL=http://localhost:8060
 ```      
 
+Bygge fpmock lokalt. Imaget blir da tilgjengelig som fpmock2:latest
+```
+docker build -t fpmock2 . 
+```

--- a/autotest/src/main/java/no/nav/foreldrepenger/autotest/aktoerer/Aktoer.java
+++ b/autotest/src/main/java/no/nav/foreldrepenger/autotest/aktoerer/Aktoer.java
@@ -4,15 +4,21 @@ import java.io.IOException;
 
 import io.qameta.allure.Step;
 import no.nav.foreldrepenger.autotest.klienter.vtp.openam.OpenamKlient;
+import no.nav.foreldrepenger.autotest.util.http.BasicHttpSession;
 import no.nav.foreldrepenger.autotest.util.http.HttpSession;
 import no.nav.foreldrepenger.autotest.util.http.SecureHttpsSession;
+import no.nav.foreldrepenger.autotest.util.konfigurasjon.MiljoKonfigurasjon;
 
 public class Aktoer {
 
     public HttpSession session;
 
     public Aktoer() {
-        session = SecureHttpsSession.session();
+        if (MiljoKonfigurasjon.getRootUrl().startsWith("https")) {
+            session = SecureHttpsSession.session();
+        } else {
+            session = BasicHttpSession.session();
+        }
     }
 
     public void erLoggetInnUtenRolle() throws IOException {

--- a/autotest/src/main/java/no/nav/foreldrepenger/autotest/base/FpoppdragTestBase.java
+++ b/autotest/src/main/java/no/nav/foreldrepenger/autotest/base/FpoppdragTestBase.java
@@ -12,7 +12,7 @@ public class FpoppdragTestBase extends TestBase {
 
     protected InntektsmeldingErketype inntektsmeldingErketype;
 
-    public FpoppdragTestBase() throws Exception {
+    public FpoppdragTestBase() {
         saksbehandler = new Saksbehandler();
         testscenarioKlient = new TestscenarioKlient(BasicHttpSession.session());
         inntektsmeldingErketype = new InntektsmeldingErketype();

--- a/autotest/src/main/java/no/nav/foreldrepenger/autotest/base/SpberegningTestBase.java
+++ b/autotest/src/main/java/no/nav/foreldrepenger/autotest/base/SpberegningTestBase.java
@@ -33,7 +33,7 @@ public class SpberegningTestBase extends TestBase {
     protected TestscenarioKlient testscenarioKlient;
     protected InntektsmeldingErketype inntektsmeldingErketype;
 
-    public SpberegningTestBase() throws Exception {
+    public SpberegningTestBase()  {
         saksbehandler = new Saksbehandler();
         fordel = new Fordel();
 

--- a/autotest/src/main/java/no/nav/foreldrepenger/autotest/klienter/vtp/VTPKlient.java
+++ b/autotest/src/main/java/no/nav/foreldrepenger/autotest/klienter/vtp/VTPKlient.java
@@ -18,11 +18,11 @@ public class VTPKlient extends JsonRest{
     @Override
     public String hentRestRotUrl() {
         if (null != System.getenv("AUTOTEST_VTP_BASE_URL")) {
-            return System.getenv("AUTOTEST_VTP_BASE_URL") + "/api";
+            return System.getenv("AUTOTEST_VTP_BASE_URL") + "/rest/api";
         } else {
             return System.getProperty("autotest.vtp.url")+":" + System.getProperty("autotest.vtp.port") + "/rest/api";
         }
-
     }
+
 
 }

--- a/autotest/src/main/java/no/nav/foreldrepenger/autotest/klienter/vtp/openam/dto/AccessTokenResponseDTO.java
+++ b/autotest/src/main/java/no/nav/foreldrepenger/autotest/klienter/vtp/openam/dto/AccessTokenResponseDTO.java
@@ -1,0 +1,20 @@
+package no.nav.foreldrepenger.autotest.klienter.vtp.openam.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccessTokenResponseDTO {
+    @JsonProperty("id_token")
+    public String idToken;
+
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+
+    @JsonProperty("access_token")
+    public String accessToken;
+
+    @JsonProperty("expires_in")
+    public int expiresIn = 3600;
+
+    @JsonProperty("token_type")
+    public String tokenType = "JWKS";
+}

--- a/autotest/src/main/java/no/nav/foreldrepenger/autotest/util/http/rest/JsonRest.java
+++ b/autotest/src/main/java/no/nav/foreldrepenger/autotest/util/http/rest/JsonRest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -111,6 +112,15 @@ public abstract class JsonRest extends Rest {
         HttpResponse response = getJson(url, headers);
         String json = hentResponseBody(response);
         ValidateResponse(response, expectedStatusRange, url + "\n\n" + json);
+        return json.equals("") ? null : hentObjectMapper().readValue(json, returnType);
+    }
+
+    protected <T> T postFormOgHentJson(String url, Map<String, String> query, Class<T> returnType) throws IOException {
+        String content = UrlEncodeQuery(query,"");
+        HttpEntity entity = new StringEntity(content, ContentType.APPLICATION_FORM_URLENCODED);
+        Map<String,String> headers = Map.of("Content-Type", ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
+        HttpResponse response = post(url, entity, headers);
+        String json = hentResponseBody(response);
         return json.equals("") ? null : hentObjectMapper().readValue(json, returnType);
     }
 

--- a/autotest/src/main/java/no/nav/foreldrepenger/autotest/util/http/rest/Rest.java
+++ b/autotest/src/main/java/no/nav/foreldrepenger/autotest/util/http/rest/Rest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.cookie.Cookie;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.cookie.BasicClientCookie;
 
@@ -20,7 +21,7 @@ public abstract class Rest {
     protected HttpSession session;
 
     protected static final String ACCEPT_TEXT_HEADER = "application/text";
-    
+
     private static final String WRONG_STATUS_MESSAGE_FORMAT = "Request returned unexpected status code expected range %s got %s\n%s";
     private static final String AUTHORIZATION_FORMAT = "Basic %s";
 
@@ -35,7 +36,7 @@ public abstract class Rest {
     /*
      * GET
      */
-    
+
     protected HttpResponse get(String url) throws IOException {
 
         return get(url, HttpSession.createEmptyHeaders());
@@ -53,11 +54,11 @@ public abstract class Rest {
     protected HttpResponse post(String url, HttpEntity entity) throws IOException {
         return post(url, entity, HttpSession.createEmptyHeaders());
     }
-    
+
     protected HttpResponse post(String url, String request, Map<String, String> headers) throws UnsupportedEncodingException, IOException {
         return post(url, new StringEntity(request), headers);
     }
-    
+
     protected HttpResponse post(String url, String request) throws UnsupportedEncodingException, IOException {
         return post(url, request, HttpSession.createEmptyHeaders());
     }
@@ -65,7 +66,8 @@ public abstract class Rest {
     protected HttpResponse post(String url, HttpEntity entity, Map<String, String> headers) throws IOException {
         return session.post(url, entity, headers);
     }
-    
+
+
     /*
      * PUT
      */
@@ -77,7 +79,7 @@ public abstract class Rest {
     protected HttpResponse put(String url, HttpEntity entity, Map<String, String> headers) throws IOException {
         return session.put(url, entity, headers);
     }
-    
+
     /*
      * DELETE
      */
@@ -89,18 +91,17 @@ public abstract class Rest {
     protected HttpResponse delete(String url, Map<String, String> headers) throws IOException {
         return session.delete(url, headers);
     }
-    
-    
+
 
     protected String basicAuthenticationHeaderValue(String username, String password) {
         String encodedAuth = Base64.getEncoder().encodeToString(String.format("%s:%s", username, password).getBytes(StandardCharsets.UTF_8));
         return String.format(AUTHORIZATION_FORMAT, encodedAuth);
     }
-    
+
     protected String hentResponseBody(HttpResponse response) {
         return HttpSession.readResponse(response);
     }
-    
+
     /*
      * COOKIES
      */
@@ -115,7 +116,7 @@ public abstract class Rest {
     protected void addCookie(Cookie cookie) {
         session.leggTilCookie(cookie);
     }
-    
+
     /*
      * STATUSCODE VALIDATION
      */
@@ -123,23 +124,23 @@ public abstract class Rest {
     protected void ValidateResponse(HttpResponse response, int expectedStatus) {
         ValidateResponse(response, new StatusRange(expectedStatus, expectedStatus), "");
     }
-    
+
     protected void ValidateResponse(HttpResponse response, int expectedStatus, String body) {
         ValidateResponse(response, new StatusRange(expectedStatus, expectedStatus), body);
     }
-    
+
     protected void ValidateResponse(HttpResponse response, StatusRange expectedRange) {
         ValidateResponse(response, expectedRange, "");
     }
 
     protected void ValidateResponse(HttpResponse response, StatusRange expectedRange, String body) {
         int statuscode = response.getStatusLine().getStatusCode();
-        
-        if(!expectedRange.inRange(statuscode)) {
-            if(body.equals("")) {
+
+        if (!expectedRange.inRange(statuscode)) {
+            if (body.equals("")) {
                 body = hentResponseBody(response);
             }
-            
+
             throw new RuntimeException(String.format(WRONG_STATUS_MESSAGE_FORMAT, expectedRange, statuscode, body));
         }
     }
@@ -150,9 +151,13 @@ public abstract class Rest {
     public String UrlCompose(String url, Map<String, String> data) {
         return url + UrlEncodeQuery(data);
     }
-    
+
     public String UrlEncodeQuery(Map<String, String> data) {
-        StringBuilder query = new StringBuilder("?");
+        return UrlEncodeQuery(data, "?");
+    }
+
+    public String UrlEncodeQuery(Map<String, String> data, String prefix) {
+        StringBuilder query = new StringBuilder(prefix);
         for (Map.Entry<String, String> item : data.entrySet()) {
             if (item.getValue() != null && !item.getKey().isEmpty() && !item.getValue().isEmpty()) {
                 String queryKey = UrlEncodeItem(item.getKey());

--- a/autotest/src/main/resources/localhost/localhost.properties
+++ b/autotest/src/main/resources/localhost/localhost.properties
@@ -1,6 +1,6 @@
-autotest.fpsak.http.protocol = https
+autotest.fpsak.http.protocol = http
 autotest.fpsak.http.hostname = localhost
-autotest.fpsak.http.port = 8443
+autotest.fpsak.http.port = 8080
 autotest.fpsak.http.routing.index = /fpsak
 autotest.fpsak.http.routing.selftest = /fpsak/internal/selftest
 autotest.fpsak.http.routing.metrics = /fpsak/internal/metrics

--- a/server/src/main/java/no/nav/foreldrepenger/fpmock2/server/rest/WellKnownResponse.java
+++ b/server/src/main/java/no/nav/foreldrepenger/fpmock2/server/rest/WellKnownResponse.java
@@ -93,19 +93,19 @@ class WellKnownResponse {
 
     public WellKnownResponse(String url, String issuer) {
         this.issuer = issuer;
-        this.endSessionEndpoint = url + "/isso/oauth2/connect/endSession";
-        this.checkSessionIframe = url + "/isso/oauth2/connect/checkSession";
+        this.endSessionEndpoint = url + "/rest/isso/oauth2/connect/endSession";
+        this.checkSessionIframe = url + "/rest/isso/oauth2/connect/checkSession";
         /**
          * Gjør det mulig å kjøre redirect flow i browseren når vi kjører med docker-compose.
          */
         if (null != System.getenv("AUTHORIZE_BASE_URL")) {
-            this.authorizationEndpoint = System.getenv("AUTHORIZE_BASE_URL") + "/isso/oauth2/authorize";
+            this.authorizationEndpoint = System.getenv("AUTHORIZE_BASE_URL") + "/rest/isso/oauth2/authorize";
         } else {
-            this.authorizationEndpoint = url + "/isso/oauth2/authorize";
+            this.authorizationEndpoint = url + "/rest/isso/oauth2/authorize";
         }
-        this.jwksUri = url + "/isso/oauth2/connect/jwk_uri";
-        this.registrationEndpoint = url + "/isso/oauth2/connect/register";
-        this.tokenEndpoint = url + "/isso/oauth2/access_token";
+        this.jwksUri = url + "/rest/isso/oauth2/connect/jwk_uri";
+        this.registrationEndpoint = url + "/rest/isso/oauth2/connect/register";
+        this.tokenEndpoint = url + "/rest/isso/oauth2/access_token";
     }
 
     public List<String> getResponseTypesSupported() {


### PR DESCRIPTION
Denne PR-en inneholder endringer som er oppdaget i forsøk på å kjøre FPLOS mot VTP
* OIDC henter nå tokens fra VTP i autotest noe som fjerner behovet for at disse trenger å ha satt samme issuer.
* Rettet feil på service-discovery endpoints på OIDC etter at man har gått over til /rest og /soap prefixene.
* La til kode(egne containere) for Terminere SSL på docker compose fra utsiden slik at kall som MÅ gå mot SSL slik som enkelte SOAP-kall kan gå mot https på localhost med standard modig certs.