### PR TITLE
FIX Utvidet DokarkivMock respons med et dummy dokument-objekt

### DIFF
--- a/mocks/dokarkiv-mock/src/main/java/no/nav/dokarkiv/DokarkivMock.java
+++ b/mocks/dokarkiv-mock/src/main/java/no/nav/dokarkiv/DokarkivMock.java
@@ -22,6 +22,6 @@ public class DokarkivMock {
     public Response lagJournalpost(@QueryParam("foersoekFerdigstill") Boolean foersoekFerdigstill) {
         LOG.info("Dokarkiv. Lag journalpost. foersoekFerdigstill: {}", foersoekFerdigstill);
 
-        return Response.status(200).entity("{ \"journalpostId\": 1, \"melding\": \"foo\", \"journalpostferdigstilt\": false, \"dokumenter\": [] }").build();
+        return Response.status(200).entity("{ \"journalpostId\": 1, \"melding\": \"foo\", \"journalpostferdigstilt\": false, \"dokumenter\": [ { \"dokumentInfoId\": \"12345\"} ] }").build();
     }
 }


### PR DESCRIPTION
Nødvendig for å støtte arkivering av vedlegg til brev