### PR TITLE
Støtt dato som query variable

### DIFF
--- a/mocks/saf-mock/src/main/java/no/nav/saf/graphql/DateScalar.java
+++ b/mocks/saf-mock/src/main/java/no/nav/saf/graphql/DateScalar.java
@@ -28,24 +28,28 @@ final class DateScalar {
 
 				@Override
 				public Object parseValue(Object input) throws CoercingParseValueException {
-					throw new CoercingParseValueException("Parsing av query variabel " + input.getClass() + " til " + DATE.getName() + " er ikke implementert.");
+					return parseDateFromString(input);
 				}
 
 				@Override
 				public Object parseLiteral(Object input) throws CoercingParseLiteralException {
-					if (input instanceof StringValue) {
-						try {
-							return LocalDate.parse(((StringValue) input).getValue());
-						} catch (DateTimeParseException e) {
-							throw new CoercingParseLiteralException("Verdi er ikke en gyldig Date: " + input.toString());
-						}
-					}
-					throw new CoercingParseLiteralException("Verdi er ikke en gyldig Date: " + input.toString());
+					return parseDateFromString(input);
 				}
 			})
 			.build();
 
 	private DateScalar() {
 		// ingen instansiering
+	}
+	
+	private LocalDate createLocalDateFromString(Object input) throws CoercingParseLiteralException {
+		if (input instanceof StringValue) {
+			try {
+				return LocalDate.parse(((StringValue) input).getValue());
+			} catch (DateTimeParseException e) {
+				throw new CoercingParseLiteralException("Verdi er ikke en gyldig Date: " + input.toString());
+			}
+		}
+		throw new CoercingParseLiteralException("Verdi er ikke en gyldig Date: " + input.toString());
 	}
 }


### PR DESCRIPTION
Vi prøvde å bruke fraDato som en query variable, men det går ikke, så vidt jeg skjønner fordi `parseValue()` ikke er implementert.

Jeg har flyttet parsingen ut i en helper funksjon og endret så både `parseValue()` og `parseLiteral()` bruker den.

PS! Gjort det i GitHub sin edit-feature, og ikke har jeg skrevet Java på mange år, så ingen garanti for at dette funker 🙃