### PR TITLE
Dependabot: Bumper versjoner i en bulk. Avhengighetene det gjelder skrives i kommentar.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Publiser Release Note
         id: create_release
-        uses: actions/create-release@v1.1.4
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Publiser Release Note
         id: create_release
-        uses: actions/create-release@v1.1.3
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,10 +33,6 @@
         </dependency>
         <!-- 3dje parts biblioteker -->
         <dependency>
-        	<groupId>com.sun.xml.ws</groupId>
-        	<artifactId>jaxws-rt</artifactId>
-        </dependency>
-        <dependency>
 		    <groupId>org.junit.vintage</groupId>
 		    <artifactId>junit-vintage-engine</artifactId>
 		    <scope>test</scope>

--- a/mocks/arbeidsforhold-mock/pom.xml
+++ b/mocks/arbeidsforhold-mock/pom.xml
@@ -23,7 +23,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
+			<artifactId>resteasy-core-spi</artifactId>
 		</dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/mocks/dokdist-mock/pom.xml
+++ b/mocks/dokdist-mock/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/mocks/dokumentproduksjon-mock/pom.xml
+++ b/mocks/dokumentproduksjon-mock/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/mocks/dummy-mock/pom.xml
+++ b/mocks/dummy-mock/pom.xml
@@ -14,7 +14,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/mocks/gsak-mock/pom.xml
+++ b/mocks/gsak-mock/pom.xml
@@ -15,7 +15,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
+			<artifactId>resteasy-core-spi</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-beanutils</groupId>

--- a/mocks/infotrygd-mock/pom.xml
+++ b/mocks/infotrygd-mock/pom.xml
@@ -21,7 +21,7 @@
 	       <!-- Eksterne avhengigheter -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/mocks/infotrygd-paaroerende-sykdom-mock/pom.xml
+++ b/mocks/infotrygd-paaroerende-sykdom-mock/pom.xml
@@ -83,7 +83,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
+			<artifactId>resteasy-core-spi</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/mocks/infotrygd-paaroerende-sykdom-mock/pom.xml
+++ b/mocks/infotrygd-paaroerende-sykdom-mock/pom.xml
@@ -19,7 +19,7 @@
 			<plugin>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-codegen-maven-plugin</artifactId>
-				<version>2.4.15</version>
+				<version>2.4.16</version>
 				<executions>
 					<execution>
 						<goals>

--- a/mocks/inntekt-mock/pom.xml
+++ b/mocks/inntekt-mock/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/mocks/journalpost-mock/pom.xml
+++ b/mocks/journalpost-mock/pom.xml
@@ -34,7 +34,7 @@
 			<plugin>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-codegen-maven-plugin</artifactId>
-				<version>2.4.15</version>
+				<version>2.4.16</version>
 				<executions>
 					<execution>
 						<goals>

--- a/mocks/journalpost-mock/pom.xml
+++ b/mocks/journalpost-mock/pom.xml
@@ -16,7 +16,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
+			<artifactId>resteasy-core-spi</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>

--- a/mocks/medl-mock/pom.xml
+++ b/mocks/medl-mock/pom.xml
@@ -30,7 +30,7 @@
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
 
 

--- a/mocks/norg2-mock/pom.xml
+++ b/mocks/norg2-mock/pom.xml
@@ -21,7 +21,7 @@
 		<!-- 3dje parts biblioteker -->
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
+			<artifactId>resteasy-core-spi</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.swagger</groupId>

--- a/mocks/oppgave-mock/pom.xml
+++ b/mocks/oppgave-mock/pom.xml
@@ -14,7 +14,7 @@
 	<dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/mocks/organisasjon-mock/pom.xml
+++ b/mocks/organisasjon-mock/pom.xml
@@ -26,7 +26,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
+			<artifactId>resteasy-core-spi</artifactId>
 		</dependency>
 
 	</dependencies>

--- a/mocks/pdl-mock/pom.xml
+++ b/mocks/pdl-mock/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -67,6 +67,10 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
         </dependency>
     </dependencies>
 

--- a/mocks/pdl-mock/pom.xml
+++ b/mocks/pdl-mock/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>io.github.kobylynskyi</groupId>
             <artifactId>graphql-codegen-maven-plugin</artifactId>
-            <version>2.4.1</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -75,7 +75,7 @@
             <plugin>
                 <groupId>io.github.kobylynskyi</groupId>
                 <artifactId>graphql-codegen-maven-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -90,7 +90,9 @@
                                 <!-- <Price.amount>java.math.BigDecimal</Price.amount> -->
                             </customTypesMapping>
                             <customAnnotationsMapping>
-                                <EpochMillis>com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.example.json.EpochMillisScalarDeserializer.class</EpochMillis>
+                                <EpochMillis>
+                                    <annotation>com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.example.json.EpochMillisScalarDeserializer.class)</annotation>
+                                </EpochMillis>
                             </customAnnotationsMapping>
                             <generateClient>true</generateClient>
                             <!--<generateClient>true</generateClient>

--- a/mocks/saf-mock/pom.xml
+++ b/mocks/saf-mock/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>io.github.kobylynskyi</groupId>
                 <artifactId>graphql-codegen-maven-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -79,7 +79,9 @@
                                 <!-- <Price.amount>java.math.BigDecimal</Price.amount> -->
                             </customTypesMapping>
                             <customAnnotationsMapping>
-                                <EpochMillis>com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.example.json.EpochMillisScalarDeserializer.class</EpochMillis>
+                                <EpochMillis>
+                                    <annotation>com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.example.json.EpochMillisScalarDeserializer.class)</annotation>
+                                </EpochMillis>
                             </customAnnotationsMapping>
                         </configuration>
                     </execution>

--- a/mocks/saf-mock/pom.xml
+++ b/mocks/saf-mock/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -56,6 +56,10 @@
         <dependency>
             <groupId>no.nav.foreldrepenger.vtp</groupId>
             <artifactId>core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
         </dependency>
     </dependencies>
 

--- a/mocks/sigrun-mock/pom.xml
+++ b/mocks/sigrun-mock/pom.xml
@@ -15,7 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
+            <artifactId>resteasy-core-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/mocks/tps-mock/pom.xml
+++ b/mocks/tps-mock/pom.xml
@@ -33,7 +33,7 @@
 
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-jaxrs</artifactId>
+			<artifactId>resteasy-core-spi</artifactId>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-bom</artifactId>
-                <version>3.6.3.Final</version>
+                <version>4.5.8.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
             <dependency>
                 <groupId>net.logstash.logback</groupId>
                 <artifactId>logstash-logback-encoder</artifactId>
-                <version>5.1</version>
+                <version>6.4</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,10 @@
         <cxf.version>3.3.7</cxf.version>
         <tjenestespesifikasjoner.version>1.2020.01.20-15.44-063ae9f84815</tjenestespesifikasjoner.version>
         <swagger.version>1.6.2</swagger.version>
-        <graphql-java.version>2020-09-13T08-19-45-0d97d9d</graphql-java.version>
+        <graphql-java.version>2020-10-01T21-06-37-558aeaa</graphql-java.version>
         <ch.qos.logback.version>1.2.3</ch.qos.logback.version>
         <jupiter.version>5.7.0</jupiter.version>
-        <mockito.version>3.5.11</mockito.version>
+        <mockito.version>3.5.13</mockito.version>
 
     </properties>
 
@@ -53,7 +53,7 @@
                 <!-- NB jetty avhengigher før resteasy -->
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>9.4.31.v20200723</version>
+                <version>9.4.32.v20200930</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcomponents-client</artifactId>
-                <version>4.5.12</version>
+                <version>4.5.13</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -157,10 +157,6 @@
             <artifactId>resteasy-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
         </dependency>


### PR DESCRIPTION
Bump httpcomponents-client from 4.5.12 to 4.5.13
Bump swagger-codegen-maven-plugin from 2.4.15 to 2.4.16
Bump graphql-java from 2020-09-13T08-19-45-0d97d9d to 2020-10-01T21-06-37-558aeaa
Bump jetty-bom from 9.4.31.v20200723 to 9.4.32.v20200930
Bump graphql-codegen-maven-plugin from 2.4.1 to 3.1.1
Bump mockito.version from 3.5.11 to 3.5.13
Bump resteasy-bom from 3.6.3.Final to 4.5.8.Final
Bump actions/create-release from v1.1.3 to v1 (bruk kun major version for offisielle github actions)
Bump logstash-logback-encoder from 5.1 to 6.4