### PR TITLE
TFP-3697: Lar være å mappe fysisk dokument for PDF hvis det ikke lar …

### DIFF
--- a/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMapper.java
+++ b/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMapper.java
@@ -105,9 +105,17 @@ public class JournalpostMapper {
     }
 
     private DokumentVariantInnhold mapDokumentVariant(DokumentVariant dokumentVariant){
-        byte[] fysiskDokument = List.of("JSON","XML").contains(dokumentVariant.getFiltype()) ?
-                dokumentVariant.getFysiskDokument() : "PDFA".equals(dokumentVariant.getFiltype()) ?
-                Base64.getDecoder().decode(dokumentVariant.getFysiskDokument()) : new byte[0];
+        byte[] fysiskDokument = new byte[0];
+        if (List.of("JSON","XML").contains(dokumentVariant.getFiltype())) {
+            fysiskDokument = dokumentVariant.getFysiskDokument();
+        } else if ("PDFA".equals(dokumentVariant.getFiltype())) {
+            try {
+                fysiskDokument = Base64.getDecoder().decode(dokumentVariant.getFysiskDokument());
+            } catch (IllegalArgumentException e) {
+                // PDFen er ikke base64-enkodet - returnerer tom array for å bevare kompatibilitet med tidligere, men
+                // her kan man også vurdere å assigne dokumentVariant.getFysiskDokument() direkte hvis det blir riktig
+            }
+        }
         DokumentVariantInnhold dokumentVariantInnhold = new DokumentVariantInnhold(
                 new Arkivfiltype(dokumentVariant.getFiltype()),
                 new Variantformat(dokumentVariant.getVariantformat()),


### PR DESCRIPTION
…seg base64-dekode, slik at vi bevarer bakoverkompatiblitet.