### PR TITLE
NOJIRA fikse pdl-mock

### DIFF
--- a/mocks/pdl-mock/src/main/java/no/nav/pdl/PdlMock.java
+++ b/mocks/pdl-mock/src/main/java/no/nav/pdl/PdlMock.java
@@ -76,7 +76,11 @@ public class PdlMock {
 
     // TODO: Det er ikke støtte for å gjøre flere operasjoner på en query (f.eks. hentPerson og hentGeografiskTilknytning samtidig)
     private String hentOperationName(GraphQLRequest request) {
-        return StringUtils.substringBetween(request.getQuery(), "{", "(").trim();
+        var operasjon = StringUtils.substringBetween(request.getQuery(), "{", "(").trim();
+        if (operasjon.contains(":")) { // Alias
+            return StringUtils.substringAfter(operasjon, ":").trim();
+        }
+        return operasjon;
     }
 
 }


### PR DESCRIPTION
Felles 2.5 har graphql-codegen 4.0.0 som innfører aliaser slik. Tar hensyn når man skal finner metode
3.1.1 query {  hentIdenter(ident: "<ident>", grupper: [ FOLKEREGISTERIDENT ], historikk: false){ identer { ident } } }
4.0.0 query { hentIdenter: hentIdenter(ident: "<ident>", grupper: [ FOLKEREGISTERIDENT ], historikk: false){ identer { ident } } }