### PR TITLE
TFP-4009: Legger til endepunkt i JournalforingRestTjeneste.

### DIFF
--- a/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMapper.java
+++ b/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMapper.java
@@ -62,16 +62,14 @@ public class JournalpostMapper {
                             .collect(Collectors.toList()));
         }
         modell.setDokumentModellList(dokumentModeller);
-
-
+        modell.setTittel(journalpostRequest.getTittel());
+        modell.setEksternReferanseId(journalpostRequest.getEksternReferanseId());
+        modell.setMottakskanal(journalpostRequest.getKanal());
 
         //TODO: Hvordan håndteres denne (getAvsenderMottaker) sammenlignet med bruker? & Map felter videre
         journalpostRequest.getAvsenderMottaker();
         journalpostRequest.getBehandlingstema();
-        journalpostRequest.getTittel();
         journalpostRequest.getTilleggsopplysninger();
-        journalpostRequest.getEksternReferanseId();
-        journalpostRequest.getKanal();
 
         return modell;
 

--- a/mocks/kafka-embedded-mock/src/main/java/no/nav/foreldrepenger/vtp/kafkaembedded/LocalKafkaProducer.java
+++ b/mocks/kafka-embedded-mock/src/main/java/no/nav/foreldrepenger/vtp/kafkaembedded/LocalKafkaProducer.java
@@ -62,15 +62,15 @@ public class LocalKafkaProducer {
         return props;
     }
 
-    public void sendMelding(String topic, String key, String value) {
-        stringProducer.send(new ProducerRecord<>(topic, key, value), (recordMetadata, e) -> {
+    public void sendMelding(String topic, String value) {
+        stringProducer.send(new ProducerRecord<>(topic, value), (recordMetadata, e) -> {
             LOG.info("Received new metadata: [topic: {} partition: {} offset: {}]", recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset());
         });
         stringProducer.flush();
     }
 
-    public void sendMelding(String topic, String value) {
-        stringProducer.send(new ProducerRecord<>(topic, value), (recordMetadata, e) -> {
+    public void sendMelding(String topic, String key, String value) {
+        stringProducer.send(new ProducerRecord<>(topic, key, value), (recordMetadata, e) -> {
             LOG.info("Received new metadata: [topic: {} partition: {} offset: {}]", recordMetadata.topic(), recordMetadata.partition(), recordMetadata.offset());
         });
         stringProducer.flush();

--- a/mocks/saf-mock/src/main/resources/schemas/saf.graphql
+++ b/mocks/saf-mock/src/main/resources/schemas/saf.graphql
@@ -108,7 +108,7 @@ type Query {
 
         # Peker til resultat etter foerste, brukes til å paginere forover.
         etter: String
-     ): Dokumentoversikt!
+    ): Dokumentoversikt!
 
     # * dokumentoversiktJournalstatus returnerer en liste som matcher søkeparameterene.
     # * Det er kun metadata om journalposter med tilhørende dokumenter som returneres. Det fysiske dokumentet kan hentes i saf - REST hentdokument.
@@ -137,14 +137,14 @@ type Query {
 
         # Peker til resultat etter foerste, brukes til å paginere forover.
         etter: String
-     ): Dokumentoversikt!
+    ): Dokumentoversikt!
 
     # * Query returnerer metadata for en journalpost.
     # * Fysiske dokumentet tilknyttet journalposten kan hentes i saf - REST hentdokument
     journalpost(
-       # ID til Journalposten man ønsker å hente detaljer for.
-       # * Hvis argumentet ikke er angitt så returneres en feil.
-       journalpostId: String!
+        # ID til Journalposten man ønsker å hente detaljer for.
+        # * Hvis argumentet ikke er angitt så returneres en feil.
+        journalpostId: String!
     ): Journalpost
 
     # Henter metadata for en dokumentInfo (dokumentbeskrivelse) med tilknyttede journalposter.
@@ -152,12 +152,12 @@ type Query {
     # * Deler samme DokumentInfo (mange-til-mange relasjon via JPDokInfoRel). Dette vil typisk være resultat av et dokument som er journalført på flere saker/brukere.
     # * Er knyttet sammen via originalJournalpostId. Dette vil typisk være resultat av en splitting av et dokument, der det opprettes to nye DokumentInfo med hver sin del av originaldokumentet, og DokumentInfo.originalJournalpostId peker tilbake på journalposten (med status Utgått) som originaldokumentet lå på.
     tilknyttedeJournalposter(
-       # ID til dokumentet man ønsker å hente tilknyttede Journalpost for.
-       # * Hvis argumentet ikke er angitt så returneres en feil.
-       dokumentInfoId: String!
+        # ID til dokumentet man ønsker å hente tilknyttede Journalpost for.
+        # * Hvis argumentet ikke er angitt så returneres en feil.
+        dokumentInfoId: String!
 
-       # Typen tilknyttet Journalpost.
-       tilknytning: Tilknytning!
+        # Typen tilknyttet Journalpost.
+        tilknytning: Tilknytning!
     ): [Journalpost]!
 }
 
@@ -183,10 +183,10 @@ type SideInfo {
 # * Disse er representert som et skjemaløst nøkkel-verdi-sett og valideres ikke av Joark. Et eksempel på et slikt sett kan være (bucid, 21521).
 type Tilleggsopplysning {
     # Nøkkelen til det fagspesifikke attributtet.
-	nokkel: String
+    nokkel: String
 
-	# Verdien til det fagspesifikke attributtet.
-	verdi: String
+    # Verdien til det fagspesifikke attributtet.
+    verdi: String
 }
 
 # Et sett med metadata som er nødvendig for å gjenfinne et dokument i arkivet. En journalpost kan ha ett eller flere dokumenter.
@@ -433,29 +433,29 @@ enum Datotype {
     # * Returneres for alle journalposter
     DATO_OPPRETTET
 
-	# * Tidspunktet dokumentene på journalposten ble sendt til print.
+    # * Tidspunktet dokumentene på journalposten ble sendt til print.
     # * Returneres for utgående journalposter
-	DATO_SENDT_PRINT
+    DATO_SENDT_PRINT
 
-	# * Tidspunktet dokumentene på journalposten ble sendt til bruker.
+    # * Tidspunktet dokumentene på journalposten ble sendt til bruker.
     # * Returneres for utgående journalposter
-	DATO_EKSPEDERT
+    DATO_EKSPEDERT
 
-	# * Tidspunktet journalposten ble journalført (inngående) eller ferdigstilt (utgående).
+    # * Tidspunktet journalposten ble journalført (inngående) eller ferdigstilt (utgående).
     # * Returneres for alle journalposttyper
-	DATO_JOURNALFOERT
+    DATO_JOURNALFOERT
 
-	# * Tidspunkt dokumentene i journalposten ble registrert i NAV sine systemer.
+    # * Tidspunkt dokumentene i journalposten ble registrert i NAV sine systemer.
     # * Returneres for inngående journalposter
     DATO_REGISTRERT
 
-	# * Tidspunkt som dokumentene i journalposten ble sendt på nytt, grunnet retur av opprinnelig forsendelse.
+    # * Tidspunkt som dokumentene i journalposten ble sendt på nytt, grunnet retur av opprinnelig forsendelse.
     # * Returneres for utgående journalposter
-	DATO_AVS_RETUR
+    DATO_AVS_RETUR
 
     # * Dato på hoveddokumentet i forsendelsen. Registreres i noen tilfeller manuelt av saksbehandler.
     # * Returneres for alle journalposter
-	DATO_DOKUMENT
+    DATO_DOKUMENT
 
 }
 
@@ -472,13 +472,13 @@ enum Arkivsaksystem {
 # Sier hvorvidt journalposten er et inngående dokument, et utgående dokument eller et notat.
 enum Journalposttype {
     # **Inngående dokument** - Dokumentasjon som NAV har mottatt fra en ekstern part. De fleste inngående dokumenter er søknader, ettersendelser av dokumentasjon til sak, eller innsendinger fra arbeidsgivere. Meldinger brukere har sendt til "Skriv til NAV" arkiveres også som inngående dokumenter..
-	I
+    I
 
-	# **Unngående dokument** - Dokumentasjon som NAV har produsert og sendt ut til en ekstern part. De fleste utgående dokumenter er informasjons- eller vedtaksbrev til privatpersoner eller organisasjoner. "Skriv til NAV"-meldinger som saksbehandlere har sendt til brukere arkiveres også som utgående dokumenter.
-	U
+    # **Unngående dokument** - Dokumentasjon som NAV har produsert og sendt ut til en ekstern part. De fleste utgående dokumenter er informasjons- eller vedtaksbrev til privatpersoner eller organisasjoner. "Skriv til NAV"-meldinger som saksbehandlere har sendt til brukere arkiveres også som utgående dokumenter.
+    U
 
-	# **Notat** - Dokumentasjon som NAV har produsert selv, uten at formålet er å distribuere dette ut av NAV. Eksempler på notater er samtalereferater med veileder på kontaktsenter og interne forvaltningsnotater.
-	N
+    # **Notat** - Dokumentasjon som NAV har produsert selv, uten at formålet er å distribuere dette ut av NAV. Eksempler på notater er samtalereferater med veileder på kontaktsenter og interne forvaltningsnotater.
+    N
 }
 
 # * Status på journalposten i arkivet, f.eks. **MOTTATT** eller **JOURNALFOERT**. Journalstatusen gir et indikasjon på hvor i journalførings- eller dokumentproduksjonsprosessen journalposten befinner seg.
@@ -544,39 +544,43 @@ enum Kanal {
 
     # Forsendelsen er mottatt eller distribuert via applikasjoner som EU har levert og som benyttes for utveksling av informasjon med andre EU-land.
     # * Brukes for inngående og utgående journalposter.
-	EESSI
+    EESSI
 
-	# Forsendelsen er arkivert av applikasjonen EIA.
-	# * Brukes for inngående journalposter.
-	EIA
-
-	# Dokumentene i journalposten er hentet fra en ekstern kilde, for eksempel informasjon om oppholdstillatelse fra Utlendingsdirektoratet.
-	# * Brukes for inngående journalposter.
-	EKST_OPPS
-
-	# Brevet er skrevet ut lokalt og kan være sendt i posten på papir.
-	# * Brukes for utgående journalposter og notater.
-	LOKAL_UTSKRIFT
-
-	# Forsendelsen er sendt inn digitalt via selvbetjeningsløsninger på nav.no, eller distribuert digitalt til brukers meldingsboks på nav.no.
-	# * Brukes for inngående og utgående journalposter.
-	NAV_NO
-
-	# Brevet er overført til sentral distribusjon og sendt i posten på papir.
-	# * Brukes for utgående journalposter.
-	SENTRAL_UTSKRIFT
-
-	# Brevet er sendt via digital post til innbyggere.
-	# * Brukes for utgående journalposter.
-	SDP
-
-	# Forsendelsen er sendt inn på papir og skannet hos NETS.
-	# * Brukes for inngående, utgående journalposter og notater.
-	SKAN_NETS
-
-	# Forsendelsen er sendt inn på papir og skannet på NAVs skanningsenter for pensjon og bidrag.
+    # Forsendelsen er arkivert av applikasjonen EIA.
     # * Brukes for inngående journalposter.
-	SKAN_PEN
+    EIA
+
+    # Dokumentene i journalposten er hentet fra en ekstern kilde, for eksempel informasjon om oppholdstillatelse fra Utlendingsdirektoratet.
+    # * Brukes for inngående journalposter.
+    EKST_OPPS
+
+    # Brevet er skrevet ut lokalt og kan være sendt i posten på papir.
+    # * Brukes for utgående journalposter og notater.
+    LOKAL_UTSKRIFT
+
+    # Forsendelsen er sendt inn digitalt via selvbetjeningsløsninger på nav.no, eller distribuert digitalt til brukers meldingsboks på nav.no.
+    # * Brukes for inngående og utgående journalposter.
+    NAV_NO
+
+    # Brevet er overført til sentral distribusjon og sendt i posten på papir.
+    # * Brukes for utgående journalposter.
+    SENTRAL_UTSKRIFT
+
+    # Brevet er sendt via digital post til innbyggere.
+    # * Brukes for utgående journalposter.
+    SDP
+
+    # Forsendelsen er sendt inn på papir og skannet hos NETS.
+    # * Brukes for inngående, utgående journalposter og notater.
+    SKAN_NETS
+
+    # Forsendelsen er sendt inn på papir og skannet på NAVs skanningsenter for pensjon og bidrag.
+    # * Brukes for inngående journalposter.
+    SKAN_PEN
+
+    # Forsendelsen er sendt inn på papir og skannet hos Iron Moutain.
+    # * Brukes for inngående, utgående journalposter og notater.
+    SKAN_IM
 
     # Forsendelen er distribuert via integrasjonspunkt for eFormidling til Trygderetten.
     # * Brukes for utgående journalposter.
@@ -587,15 +591,18 @@ enum Kanal {
     HELSENETTET
 
     # Forsendelsen skal ikke distribueres ut av NAV.
-	# * Brukes for alle notater og noen utgående journalposter
-	INGEN_DISTRIBUSJON
+    # * Brukes for alle notater og noen utgående journalposter
+    INGEN_DISTRIBUSJON
 
     # Forsendelsen er sendt inn digitalt via selvbetjeningsløsninger på nav.no, uten at avsenderen ble digitalt autentisert
     # * Brukes for inngående journalposter
     NAV_NO_UINNLOGGET
 
-	# Forsendelsen har ingen kjent kanal.
-	UKJENT
+    # Bruker har fylt ut og sendt inn dokumentet sammen med en NAV-ansatt. Det er den NAV-ansatte som var pålogget innsendingsløsningen.
+    INNSENDT_NAV_ANSATT
+
+    # Forsendelsen har ingen kjent kanal.
+    UKJENT
 }
 
 # Temaet/Fagområdet som en journalpost og tilhørende sak tilhører, f.eks. **FOR** (foreldrepenger).
@@ -639,6 +646,9 @@ enum Tema {
 
     # Forsikring
     FOS
+
+    # Midlertidig kompensasjonsordning for selvstendig næringsdrivende og frilansere
+    FRI
 
     # Fullmakt
     FUL
@@ -822,14 +832,14 @@ enum AvsenderMottakerIdType {
     ORGNR
 
     # Helsepersonellregisterets identifikator for leger og annet helsepersonell.
-     HPRNR
+    HPRNR
 
     # Unik identifikator for utenlandske institusjoner / organisasjoner. Identifikatorene vedlikeholdes i EUs institusjonskatalog.
-     UTL_ORG
+    UTL_ORG
 
     # AvsenderMottakerId er tom
-     NULL
+    NULL
 
     # Ukjent IdType
-     UKJENT
+    UKJENT
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/DokumentModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/DokumentModell.java
@@ -2,11 +2,19 @@ package no.nav.foreldrepenger.vtp.testmodell.dokument.modell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.DokumentTilknyttetJournalpost;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Dokumentkategori;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.DokumenttypeId;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class DokumentModell {
 
     private String dokumentId;
@@ -19,7 +27,29 @@ public class DokumentModell {
     private List<DokumentVariantInnhold> dokumentVariantInnholdListe = new ArrayList<>();
     private Dokumentkategori dokumentkategori;
 
+    public DokumentModell() {
+    }
 
+    @JsonCreator
+    public DokumentModell(@JsonProperty("dokumentId") String dokumentId,
+                          @JsonProperty("dokumenttypeId") DokumenttypeId dokumenttypeId,
+                          @JsonProperty("erSensitiv") Boolean erSensitiv,
+                          @JsonProperty("tittel") String tittel,
+                          @JsonProperty("brevkode") String brevkode,
+                          @JsonProperty("innhold") String innhold,
+                          @JsonProperty("dokumentTilknyttetJournalpost") DokumentTilknyttetJournalpost dokumentTilknyttetJournalpost,
+                          @JsonProperty("dokumentVariantInnholdListe") List<DokumentVariantInnhold> dokumentVariantInnholdListe,
+                          @JsonProperty("dokumentkategori") Dokumentkategori dokumentkategori) {
+        this.dokumentId = dokumentId;
+        this.dokumenttypeId = dokumenttypeId;
+        this.erSensitiv = erSensitiv;
+        this.tittel = tittel;
+        this.brevkode = brevkode;
+        this.innhold = innhold;
+        this.dokumentTilknyttetJournalpost = dokumentTilknyttetJournalpost;
+        this.dokumentVariantInnholdListe = dokumentVariantInnholdListe;
+        this.dokumentkategori = dokumentkategori;
+    }
 
     public String getDokumentId() {
         return dokumentId;
@@ -87,5 +117,33 @@ public class DokumentModell {
 
     public void setBrevkode(String brevkode) {
         this.brevkode = brevkode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DokumentModell that = (DokumentModell) o;
+        return Objects.equals(dokumentId, that.dokumentId) && Objects.equals(dokumenttypeId, that.dokumenttypeId) && Objects.equals(erSensitiv, that.erSensitiv) && Objects.equals(tittel, that.tittel) && Objects.equals(brevkode, that.brevkode) && Objects.equals(innhold, that.innhold) && Objects.equals(dokumentTilknyttetJournalpost, that.dokumentTilknyttetJournalpost) && Objects.equals(dokumentVariantInnholdListe, that.dokumentVariantInnholdListe) && Objects.equals(dokumentkategori, that.dokumentkategori);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dokumentId, dokumenttypeId, erSensitiv, tittel, brevkode, innhold, dokumentTilknyttetJournalpost, dokumentVariantInnholdListe, dokumentkategori);
+    }
+
+    @Override
+    public String toString() {
+        return "DokumentModell{" +
+                "dokumentId='" + dokumentId + '\'' +
+                ", dokumenttypeId=" + dokumenttypeId +
+                ", erSensitiv=" + erSensitiv +
+                ", tittel='" + tittel + '\'' +
+                ", brevkode='" + brevkode + '\'' +
+                ", innhold='" + innhold + '\'' +
+                ", dokumentTilknyttetJournalpost=" + dokumentTilknyttetJournalpost +
+                ", dokumentVariantInnholdListe=" + dokumentVariantInnholdListe +
+                ", dokumentkategori=" + dokumentkategori +
+                '}';
     }
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/DokumentVariantInnhold.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/DokumentVariantInnhold.java
@@ -1,13 +1,30 @@
 package no.nav.foreldrepenger.vtp.testmodell.dokument.modell;
 
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Arkivfiltype;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Variantformat;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class DokumentVariantInnhold {
 
     private Arkivfiltype filType;
     private byte[] dokumentInnhold;
     private Variantformat variantFormat;
+
+    public DokumentVariantInnhold(@JsonProperty("arkivfiltype") Arkivfiltype arkivfiltype,
+                                  @JsonProperty("variantformat") Variantformat variantformat,
+                                  @JsonProperty("dokumentInnhold") byte[] dokumentInnhold){
+        this.dokumentInnhold = dokumentInnhold;
+        this.variantFormat = variantformat;
+        this.filType = arkivfiltype;
+    }
 
     public Arkivfiltype getFilType() {
         return filType;
@@ -33,10 +50,27 @@ public class DokumentVariantInnhold {
         this.variantFormat = variantFormat;
     }
 
-    public DokumentVariantInnhold(Arkivfiltype arkivfiltype, Variantformat variantformat, byte[] dokumentInnhold){
-        this.dokumentInnhold = dokumentInnhold;
-        this.variantFormat = variantformat;
-        this.filType = arkivfiltype;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DokumentVariantInnhold that = (DokumentVariantInnhold) o;
+        return Objects.equals(filType, that.filType) && Arrays.equals(dokumentInnhold, that.dokumentInnhold) && Objects.equals(variantFormat, that.variantFormat);
     }
 
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(filType, variantFormat);
+        result = 31 * result + Arrays.hashCode(dokumentInnhold);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DokumentVariantInnhold{" +
+                "filType=" + filType +
+                ", dokumentInnhold=" + Arrays.toString(dokumentInnhold) +
+                ", variantFormat=" + variantFormat +
+                '}';
+    }
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostBruker.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostBruker.java
@@ -1,13 +1,22 @@
 package no.nav.foreldrepenger.vtp.testmodell.dokument.modell;
 
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.BrukerType;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class JournalpostBruker {
     private String ident;
     private BrukerType brukerType;
 
 
-    public JournalpostBruker(String ident, BrukerType brukerType) {
+    public JournalpostBruker(@JsonProperty("ident") String ident,
+                             @JsonProperty("brukerType") BrukerType brukerType) {
         this.ident = ident;
         this.brukerType = brukerType;
     }
@@ -26,5 +35,26 @@ public class JournalpostBruker {
 
     public void setBrukerType(BrukerType brukerType) {
         this.brukerType = brukerType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JournalpostBruker that = (JournalpostBruker) o;
+        return Objects.equals(ident, that.ident) && Objects.equals(brukerType, that.brukerType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ident, brukerType);
+    }
+
+    @Override
+    public String toString() {
+        return "JournalpostBruker{" +
+                "ident='" + ident + '\'' +
+                ", brukerType=" + brukerType +
+                '}';
     }
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
@@ -3,14 +3,24 @@ package no.nav.foreldrepenger.vtp.testmodell.dokument.modell;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Arkivtema;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Journalposttyper;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Journalstatus;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class JournalpostModell {
 
     private String journalpostId;
+    private String eksternReferanseId;
+    private String tittel;
     private List<DokumentModell> dokumentModellList = new ArrayList<>();
     private String avsenderFnr;
     private String sakId;
@@ -24,12 +34,64 @@ public class JournalpostModell {
     private Journalposttyper journalposttype;
     private JournalpostBruker bruker;
 
+    public JournalpostModell() {
+    }
+
+    @JsonCreator
+    public JournalpostModell(@JsonProperty("journalpostId") String journalpostId,
+                             @JsonProperty("eksternReferanseId") String eksternReferanseId,
+                             @JsonProperty("tittel") String tittel,
+                             @JsonProperty("dokumentModellList") List<DokumentModell> dokumentModellList,
+                             @JsonProperty("avsenderFnr") String avsenderFnr,
+                             @JsonProperty("sakId") String sakId,
+                             @JsonProperty("fagsystemId") String fagsystemId,
+                             @JsonProperty("journalStatus") Journalstatus journalStatus,
+                             @JsonProperty("kommunikasjonsretning") String kommunikasjonsretning,
+                             @JsonProperty("mottattDato") LocalDateTime mottattDato,
+                             @JsonProperty("mottakskanal") String mottakskanal,
+                             @JsonProperty("arkivtema") Arkivtema arkivtema,
+                             @JsonProperty("journaltilstand") String journaltilstand,
+                             @JsonProperty("journalposttype") Journalposttyper journalposttype,
+                             @JsonProperty("bruker") JournalpostBruker bruker) {
+        this.journalpostId = journalpostId;
+        this.eksternReferanseId = eksternReferanseId;
+        this.tittel = tittel;
+        this.dokumentModellList = dokumentModellList;
+        this.avsenderFnr = avsenderFnr;
+        this.sakId = sakId;
+        this.fagsystemId = fagsystemId;
+        this.journalStatus = journalStatus;
+        this.kommunikasjonsretning = kommunikasjonsretning;
+        this.mottattDato = mottattDato;
+        this.mottakskanal = mottakskanal;
+        this.arkivtema = arkivtema;
+        this.journaltilstand = journaltilstand;
+        this.journalposttype = journalposttype;
+        this.bruker = bruker;
+    }
+
     public String getJournalpostId() {
         return journalpostId;
     }
 
     public void setJournalpostId(String journalpostId) {
         this.journalpostId = journalpostId;
+    }
+
+    public String getEksternReferanseId() {
+        return eksternReferanseId;
+    }
+
+    public void setEksternReferanseId(String eksternReferanseId) {
+        this.eksternReferanseId = eksternReferanseId;
+    }
+
+    public void setTittel(String tittel) {
+        this.tittel = tittel;
+    }
+
+    public String getTittel() {
+        return tittel;
     }
 
     public List<DokumentModell> getDokumentModellList() {
@@ -122,6 +184,20 @@ public class JournalpostModell {
 
     public void setBruker(JournalpostBruker bruker) {
         this.bruker = bruker;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JournalpostModell that = (JournalpostModell) o;
+        return Objects.equals(journalpostId, that.journalpostId) && Objects.equals(eksternReferanseId, that.eksternReferanseId) && Objects.equals(tittel, that.tittel) && Objects.equals(dokumentModellList, that.dokumentModellList) && Objects.equals(avsenderFnr, that.avsenderFnr) && Objects.equals(sakId, that.sakId) && Objects.equals(fagsystemId, that.fagsystemId) && Objects.equals(journalStatus, that.journalStatus) && Objects.equals(kommunikasjonsretning, that.kommunikasjonsretning) && Objects.equals(mottattDato, that.mottattDato) && Objects.equals(mottakskanal, that.mottakskanal) && Objects.equals(arkivtema, that.arkivtema) && Objects.equals(journaltilstand, that.journaltilstand) && Objects.equals(journalposttype, that.journalposttype) && Objects.equals(bruker, that.bruker);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(journalpostId, eksternReferanseId, tittel, dokumentModellList, avsenderFnr, sakId, fagsystemId, journalStatus, kommunikasjonsretning, mottattDato, mottakskanal, arkivtema, journaltilstand, journalposttype, bruker);
     }
 
     @Override

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BrukerType.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BrukerType.java
@@ -1,11 +1,11 @@
 package no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public class BrukerType {
 
@@ -46,7 +46,7 @@ public class BrukerType {
         } else if (obj == null || !obj.getClass().equals(this.getClass())) {
             return false;
         }
-        return Objects.equals(getKode(), ((Journalposttyper) obj).getKode());
+        return Objects.equals(getKode(), ((BrukerType) obj).getKode());
     }
 
     @Override

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/Journalstatus.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/Journalstatus.java
@@ -28,10 +28,10 @@ public class Journalstatus {
 
     private String kode;
 
-    public static Journalstatus JOURNALFØRT = new Journalstatus("J");
-    public static Journalstatus MOTTATT = new Journalstatus("MO");
-    public static Journalstatus MIDLERTIDIG_JOURNALFØRT = new Journalstatus("M");
-    public static Journalstatus AVBRUTT = new Journalstatus("A");
+    public final static Journalstatus JOURNALFØRT = new Journalstatus("J");
+    public final static Journalstatus MOTTATT = new Journalstatus("MO");
+    public final static Journalstatus MIDLERTIDIG_JOURNALFØRT = new Journalstatus("M");
+    public final static Journalstatus AVBRUTT = new Journalstatus("A");
 
     public Journalstatus(String kode){
         this.kode = kode == null ? this.kode : kode;

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/Variantformat.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/Variantformat.java
@@ -51,7 +51,7 @@ public class Variantformat {
         } else if (obj == null || !obj.getClass().equals(this.getClass())) {
             return false;
         }
-        return Objects.equals(getKode(), ((Arkivtema) obj).getKode());
+        return Objects.equals(getKode(), ((Variantformat) obj).getKode());
     }
 
     @Override

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/repo/impl/JournalRepositoryImpl.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/repo/impl/JournalRepositoryImpl.java
@@ -21,6 +21,7 @@ public class JournalRepositoryImpl implements JournalRepository {
 
     private AtomicInteger journalpostId;
     private AtomicInteger dokumentId;
+    private AtomicInteger eksternReferanseId;
 
     private static JournalRepositoryImpl instance;
 
@@ -41,6 +42,7 @@ public class JournalRepositoryImpl implements JournalRepository {
         dokumenter = new ConcurrentHashMap<>();
         journalpostId = new AtomicInteger(Integer.parseInt(LocalDateTime.now().format(formatter)) * 100);
         dokumentId = new AtomicInteger(Integer.parseInt(LocalDateTime.now().format(formatter)) * 100);
+        eksternReferanseId = new AtomicInteger(0);
     }
 
     @Override
@@ -77,6 +79,9 @@ public class JournalRepositoryImpl implements JournalRepository {
             journalpostModell.setJournalpostId(journalpostId);
         }
 
+        journalpostModell.setEksternReferanseId(journalpostModell.getEksternReferanseId() != null ?
+                journalpostModell.getEksternReferanseId() : genererEksternReferanseId());
+
         for(DokumentModell dokumentModell : journalpostModell.getDokumentModellList()){
             String dokumentId = "";
             if(dokumentModell.getDokumentId() != null && !journalpostModell.getJournalpostId().isEmpty()){
@@ -109,7 +114,8 @@ public class JournalRepositoryImpl implements JournalRepository {
         return Integer.toString(dokumentId.incrementAndGet());
     }
 
-
-
+    public String genererEksternReferanseId() {
+        return "AR" + String.format("%08d", eksternReferanseId.incrementAndGet());
+    }
 
 }

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/ArbeidsforholdSeraliseringDeseraliseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/ArbeidsforholdSeraliseringDeseraliseringsTest.java
@@ -16,7 +16,7 @@ import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.arbeidsforhold.Permisj
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.arbeidsforhold.Yrke;
 
 
-class ArbeidsforholdSeraliseringDeseraliseringsTest extends SerializationTestBase {
+class ArbeidsforholdSeraliseringDeseraliseringsTest extends TestscenarioSerializationTestBase {
 
     @Test
     public void AntallTimerIPeriodenSeraliseringDeseraliseringTest() {

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/ArenaSeraliseringDeseraliseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/ArenaSeraliseringDeseraliseringsTest.java
@@ -16,7 +16,7 @@ import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.arena.RelatertYtelseTe
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.arena.SakStatus;
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.arena.VedtakStatus;
 
-class ArenaSeraliseringDeseraliseringsTest extends SerializationTestBase {
+class ArenaSeraliseringDeseraliseringsTest extends TestscenarioSerializationTestBase {
 
     @Test
     public void ArenaMeldekortSeraliseringDeseraliseringTest() {

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/InfotrygdSeraliseringDeseraliseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/InfotrygdSeraliseringDeseraliseringsTest.java
@@ -17,7 +17,7 @@ import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.infotrygd.beregningsgr
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.infotrygd.beregningsgrunnlag.InfotrygdVedtak;
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.infotrygd.ytelse.InfotrygdYtelse;
 
-class InfotrygdSeraliseringDeseraliseringsTest extends SerializationTestBase {
+class InfotrygdSeraliseringDeseraliseringsTest extends TestscenarioSerializationTestBase {
 
     @Test
     public void InfotrygdTemaSeraliseringDeseraliseringTest() {

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/InntektYtelseModellSeraliseringDeseraliseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/InntektYtelseModellSeraliseringDeseraliseringsTest.java
@@ -11,7 +11,7 @@ import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.InntektYtelseModell;
 import no.nav.foreldrepenger.vtp.testmodell.util.JacksonObjectMapperTestscenarioUtvider;
 import no.nav.foreldrepenger.vtp.testmodell.util.VariabelContainer;
 
-class InntektYtelseModellSeraliseringDeseraliseringsTest extends SerializationTestBase {
+class InntektYtelseModellSeraliseringDeseraliseringsTest extends TestscenarioSerializationTestBase {
 
     private static ArbeidsforholdSeraliseringDeseraliseringsTest arbeidsforhold;
     private static ArenaSeraliseringDeseraliseringsTest arena;

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/InntektskomponentSeraliseringDeseraliseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/InntektskomponentSeraliseringDeseraliseringsTest.java
@@ -18,7 +18,7 @@ import no.nav.foreldrepenger.vtp.testmodell.personopplysning.PersonArbeidsgiver;
 import no.nav.foreldrepenger.vtp.testmodell.util.JacksonObjectMapperTestscenarioUtvider;
 import no.nav.foreldrepenger.vtp.testmodell.util.VariabelContainer;
 
-class InntektskomponentSeraliseringDeseraliseringsTest extends SerializationTestBase {
+class InntektskomponentSeraliseringDeseraliseringsTest extends TestscenarioSerializationTestBase {
 
     @BeforeAll
     private static void utvidObjectmapperMedInjectables() {

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/OmsorgpengerSeraliseringDeseraliseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/OmsorgpengerSeraliseringDeseraliseringsTest.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.omsorgspenger.Overfør
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.omsorgspenger.OverføringGitt;
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.omsorgspenger.Person;
 
-class OmsorgpengerSeraliseringDeseraliseringsTest extends SerializationTestBase {
+class OmsorgpengerSeraliseringDeseraliseringsTest extends TestscenarioSerializationTestBase {
 
     @Test
     public void PersonSeraliseringDeseraliseringTest() {

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/SigrunSeraliseringDeseraliseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/SigrunSeraliseringDeseraliseringsTest.java
@@ -8,7 +8,7 @@ import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.sigrun.Inntektsår;
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.sigrun.Oppføring;
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.sigrun.SigrunModell;
 
-class SigrunSeraliseringDeseraliseringsTest extends SerializationTestBase {
+class SigrunSeraliseringDeseraliseringsTest extends TestscenarioSerializationTestBase {
 
     @Test
     public void InntektsårSeraliseringDeseraliseringTest() {

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/TestscenarioSerializationTestBase.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/TestscenarioSerializationTestBase.java
@@ -1,0 +1,52 @@
+package no.nav.foreldrepenger.vtp.testmodell.jackson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import no.nav.foreldrepenger.vtp.testmodell.util.JacksonObjectMapperTestscenario;
+
+public class TestscenarioSerializationTestBase {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(TestscenarioSerializationTestBase.class);
+    protected static ObjectMapper mapper;
+
+    @BeforeAll
+    public static void beforeAll() {
+        mapper = JacksonObjectMapperTestscenario.getObjectMapper();
+    }
+
+    protected static void test(Object obj) {
+        test(obj, true);
+    }
+
+    private static String serialize(Object obj) throws JsonProcessingException {
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+    }
+
+    private static void test(Object obj, boolean log) {
+        try {
+            if (log) {
+                LOG.info("{}", obj);
+            }
+            String serialized = serialize(obj);
+            if (log) {
+                LOG.info("Serialized as {}", serialized);
+            }
+            Object deserialized = mapper.readValue(serialized, obj.getClass());
+            if (log) {
+                LOG.info("{}", deserialized);
+            }
+            assertEquals(obj, deserialized);
+        } catch (Exception e) {
+            LOG.error("Oops", e);
+            fail(obj.getClass().getSimpleName() + " failed");
+        }
+    }
+}

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/TrexModellSeraliseringDeseralseringsTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/jackson/TrexModellSeraliseringDeseralseringsTest.java
@@ -23,7 +23,7 @@ import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.trex.Tema;
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.trex.TemaKode;
 import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.trex.Vedtak;
 
-class TrexModellSeraliseringDeseralseringsTest extends SerializationTestBase {
+class TrexModellSeraliseringDeseralseringsTest extends TestscenarioSerializationTestBase {
 
     @Test
     public void OrgnummerSeraliseringDeseraliseringTest() {

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <kafka.version>2.6.0</kafka.version>
         <avro.version>1.10.1</avro.version>
-        <confluent.version>5.5.0</confluent.version>
+        <confluent.version>6.0.1</confluent.version>
         <cxf.version>3.4.1</cxf.version>
         <tjenestespesifikasjoner.version>1.2020.01.20-15.44-063ae9f84815</tjenestespesifikasjoner.version>
         <swagger.version>1.6.2</swagger.version>
@@ -306,6 +306,11 @@
                 <groupId>no.nav.foreldrepenger.kontrakter.topics</groupId>
                 <artifactId>fp-topics-manifest</artifactId>
                 <version>5.1_20200117132228_47cdf2f</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.dok</groupId>
+                <artifactId>dok-journalfoering-hendelse-v1</artifactId>
+                <version>0.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -125,6 +125,10 @@
             <groupId>no.nav.foreldrepenger.kontrakter.topics</groupId>
             <artifactId>fp-topics-manifest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>no.nav.dok</groupId>
+            <artifactId>dok-journalfoering-hendelse-v1</artifactId>
+        </dependency>
 
         <!-- Eksterne avhengigheter -->
         <dependency>

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfig.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfig.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import io.swagger.jaxrs.config.BeanConfig;
 import no.nav.aktoerregister.rest.api.v1.AktoerIdentMock;
+import no.nav.axsys.AxsysEnhetstilgangMock;
 import no.nav.dkif.DigitalKontaktinformasjonMock;
 import no.nav.dokarkiv.JournalpostMock;
 import no.nav.dokdistfordeling.DokdistfordelingMock;
@@ -58,7 +59,6 @@ import no.nav.omsorgspenger.rammemeldinger.OmsorgspengerMock;
 import no.nav.oppgave.OppgaveMockImpl;
 import no.nav.pdl.PdlMock;
 import no.nav.saf.SafMock;
-import no.nav.axsys.AxsysEnhetstilgangMock;
 import no.nav.sigrun.SigrunMock;
 import no.nav.tjeneste.fpformidling.FpFormidlingMock;
 import no.nav.tjeneste.virksomhet.arbeidsfordeling.rest.ArbeidsfordelingRestMock;

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/JournalforingRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/JournalforingRestTjeneste.java
@@ -2,12 +2,14 @@ package no.nav.foreldrepenger.vtp.server.api.journalforing;
 
 import java.time.LocalDateTime;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -15,12 +17,13 @@ import org.slf4j.LoggerFactory;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import no.nav.foreldrepenger.vtp.kafkaembedded.LocalKafkaProducer;
+import no.nav.foreldrepenger.vtp.server.api.journalforing.hendelse.JournalforingHendelseSender;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.JournalpostModellGenerator;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.JournalpostModell;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.DokumenttypeId;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Journalstatus;
 import no.nav.foreldrepenger.vtp.testmodell.repo.JournalRepository;
-import no.nav.foreldrepenger.vtp.testmodell.repo.impl.JournalRepositoryImpl;
 
 @Api(tags = "Journalføringsmock")
 @Path("/api/journalforing")
@@ -28,14 +31,19 @@ public class JournalforingRestTjeneste {
 
     private static final Logger LOG = LoggerFactory.getLogger(JournalforingRestTjeneste.class);
 
-
     private static final String DOKUMENTTYYPEID_KEY = "dokumenttypeid";
     private static final String AKTORID_KEY = "fnr";
     private static final String JOURNALPOST_ID = "journalpostid";
     private static final String SAKSNUMMER = "saksnummer";
     private static final String JOURNALSTATUS = "journalstatus";
 
-    /** @deprecated Gammel innsending tjeneste - men tar ikke bare søknader men også inntektsmeldinger etc. */
+    @Context
+    private LocalKafkaProducer localKafkaProducer;
+
+    @Context
+    private JournalRepository journalRepository;
+
+    /** @deprecated Gammel innsending tjeneste - men tar ikke bare søknader men også inntektsmeldinger etc.  */
     @Deprecated(forRemoval=true)
     @POST
     @Path("/foreldrepengesoknadxml/fnr/{fnr}/dokumenttypeid/{dokumenttypeid}")
@@ -43,18 +51,33 @@ public class JournalforingRestTjeneste {
     @ApiOperation(value = "", notes = ("Lager en journalpost av type DokumenttypeId (se kilde for gyldige verdier, e.g. I000003). Innhold i journalpost legges ved som body."), response = JournalforingResultatDto.class)
     public JournalforingResultatDto foreldrepengesoknadErketype(String xml, @PathParam(AKTORID_KEY) String fnr, @PathParam(DOKUMENTTYYPEID_KEY) DokumenttypeId dokumenttypeId){
 
-
-
-        JournalpostModell journalpostModell = JournalpostModellGenerator.lagJournalpostStrukturertDokument(xml, fnr, dokumenttypeId);
+        var journalpostModell = JournalpostModellGenerator.lagJournalpostStrukturertDokument(xml, fnr, dokumenttypeId);
         journalpostModell.setMottattDato(LocalDateTime.now());
-        JournalRepository journalRepository = JournalRepositoryImpl.getInstance();
         String journalpostId = journalRepository.leggTilJournalpost(journalpostModell);
 
         LOG.info("Oppretter journalpost for bruke: {}. JournalpostId: {}", fnr, journalpostId);
 
-        JournalforingResultatDto res = new JournalforingResultatDto();
-        res.setJournalpostId(journalpostId);
-        return res;
+        return new JournalforingResultatDto(journalpostId);
+    }
+
+    @POST
+    @Path("/journalfor")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "", notes = ("Journalfører en allerede lagd journalpost"), response = JournalforingResultatDto.class)
+    public JournalforingResultatDto journalførJournalpost(JournalpostModell journalpostModell){
+        var journalpostId = journalRepository.leggTilJournalpost(journalpostModell);
+        LOG.info("Oppretter journalpost for bruker: {}, JournalpostId: {}", journalpostModell.getAvsenderFnr(), journalpostId);
+        var instansiertJournalpostModell = journalRepository
+                .finnJournalpostMedJournalpostId(journalpostId)
+                .orElseThrow();
+
+        if (instansiertJournalpostModell.getTittel().equalsIgnoreCase("Inntektsmelding")) {
+            var journalforingHendelseSender = new JournalforingHendelseSender(localKafkaProducer);
+            journalforingHendelseSender.leggTilJournalføringHendelsePåKafka(instansiertJournalpostModell);
+        }
+
+        return new JournalforingResultatDto(journalpostId);
     }
 
     @POST
@@ -62,37 +85,29 @@ public class JournalforingRestTjeneste {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "", notes = ("Lager en journalpost av type DokumenttypeId (se kilde for gyldige verdier, e.g. I000003). Innhold i journalpost legges ved som body."), response = JournalforingResultatDto.class)
     public JournalforingResultatDto journalførDokument(String content, @PathParam(AKTORID_KEY) String fnr, @PathParam(DOKUMENTTYYPEID_KEY) DokumenttypeId dokumenttypeId){
-        JournalpostModell journalpostModell = JournalpostModellGenerator.lagJournalpostStrukturertDokument(content, fnr, dokumenttypeId);
+        var journalpostModell = JournalpostModellGenerator.lagJournalpostStrukturertDokument(content, fnr, dokumenttypeId);
         journalpostModell.setMottattDato(LocalDateTime.now());
-        JournalRepository journalRepository = JournalRepositoryImpl.getInstance();
-        String journalpostId = journalRepository.leggTilJournalpost(journalpostModell);
+        var journalpostId = journalRepository.leggTilJournalpost(journalpostModell);
 
         LOG.info("Oppretter journalpost for bruke: {}. JournalpostId: {}", fnr, journalpostId);
 
-        JournalforingResultatDto res = new JournalforingResultatDto();
-        res.setJournalpostId(journalpostId);
-        return res;
+        return new JournalforingResultatDto(journalpostId);
     }
 
-    
     @POST
     @Path("/ustrukturertjournalpost/fnr/{fnr}/dokumenttypeid/{dokumenttypeid}")
     public JournalforingResultatDto lagUstrukturertJournalpost(@PathParam(AKTORID_KEY) String fnr, @PathParam(DOKUMENTTYYPEID_KEY) DokumenttypeId dokumenttypeid, @QueryParam(JOURNALSTATUS) String journalstatus){
-        JournalpostModell journalpostModell = JournalpostModellGenerator.lagJournalpostUstrukturertDokument(fnr,dokumenttypeid);
+        var journalpostModell = JournalpostModellGenerator.lagJournalpostUstrukturertDokument(fnr,dokumenttypeid);
         if(journalstatus != null && journalstatus.length() > 0){
-            Journalstatus status = new Journalstatus(journalstatus);
+            var status = new Journalstatus(journalstatus);
             journalpostModell.setJournalStatus(status);
         }
 
-        JournalRepository journalRepository = JournalRepositoryImpl.getInstance();
-        String journalpostId = journalRepository.leggTilJournalpost(journalpostModell);
+        var journalpostId = journalRepository.leggTilJournalpost(journalpostModell);
 
         LOG.info("Oppretter journalpost for bruker: {}. JournalpostId: {}", fnr, journalpostId);
 
-        JournalforingResultatDto response = new JournalforingResultatDto();
-        response.setJournalpostId(journalpostId);
-        return response;
-
+        return new JournalforingResultatDto(journalpostId);
     }
 
 
@@ -102,15 +117,10 @@ public class JournalforingRestTjeneste {
 
         LOG.info("Knytter sak: {} til journalpost: {}", saksnummer, journalpostId);
 
-        JournalRepository journalRepository = JournalRepositoryImpl.getInstance();
-        JournalpostModell journalpostModell = journalRepository.finnJournalpostMedJournalpostId(journalpostId).orElseThrow(()-> new NotFoundException("Kunne ikke finne journalpost"));
+        var journalpostModell = journalRepository.finnJournalpostMedJournalpostId(journalpostId).orElseThrow(()-> new NotFoundException("Kunne ikke finne journalpost"));
         journalpostModell.setSakId(saksnummer);
 
-        JournalforingResultatDto res = new JournalforingResultatDto();
-        res.setJournalpostId(journalpostId);
-        return res;
+        return new JournalforingResultatDto(journalpostId);
     }
-
-
 
 }

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/JournalforingResultatDto.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/JournalforingResultatDto.java
@@ -1,14 +1,5 @@
 package no.nav.foreldrepenger.vtp.server.api.journalforing;
 
-public class JournalforingResultatDto {
+public record JournalforingResultatDto(String journalpostId) {
 
-    private String journalpostId;
-
-    public String getJournalpostId() {
-        return journalpostId;
-    }
-
-    public void setJournalpostId(String journalpostId) {
-        this.journalpostId = journalpostId;
-    }
 }

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/hendelse/JournalforingHendelseSender.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/hendelse/JournalforingHendelseSender.java
@@ -1,0 +1,50 @@
+package no.nav.foreldrepenger.vtp.server.api.journalforing.hendelse;
+
+import java.util.UUID;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+import no.nav.foreldrepenger.vtp.kafkaembedded.LocalKafkaProducer;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.JournalpostModell;
+import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord;
+
+public class JournalforingHendelseSender {
+
+    private static final String JOURNALFØRING_TOPIC = "aapen-dok-journalfoering-v1-q1";
+    private static final String BEHANDLINGSTEMA_FORELDREPENGER_FØDSEL = "ab0047";
+
+    private LocalKafkaProducer localKafkaProducer;
+
+    public JournalforingHendelseSender(LocalKafkaProducer localKafkaProducer) {
+        this.localKafkaProducer = localKafkaProducer;
+    }
+
+    public void leggTilJournalføringHendelsePåKafka(JournalpostModell modell) {
+        localKafkaProducer.sendMelding(JOURNALFØRING_TOPIC, lagGeneriskJournalfoeringHendelseRecord(modell));
+    }
+
+    private GenericData.Record lagGeneriskJournalfoeringHendelseRecord(JournalpostModell modell) {
+        return new GenericRecordBuilder(JournalfoeringHendelseRecord.SCHEMA$)
+                .set("hendelsesId", UUID.randomUUID().toString()).set("versjon", 1)
+                .set("hendelsesType", tilHendelsesType(modell))
+                .set("journalpostId", Long.parseLong(modell.getJournalpostId()))
+                .set("journalpostStatus", modell.getJournalStatus() != null ? modell.getJournalStatus().getKode() : "M")
+                .set("temaGammelt", "")
+                .set("temaNytt", modell.getArkivtema() != null ? modell.getArkivtema().getKode() : "FOR")
+                .set("mottaksKanal", modell.getMottakskanal() != null ? modell.getMottakskanal() : "ALTINN")
+                .set("kanalReferanseId", modell.getEksternReferanseId())
+                .set("behandlingstema", BEHANDLINGSTEMA_FORELDREPENGER_FØDSEL)
+                .build();
+    }
+
+    private static String tilHendelsesType(JournalpostModell modell) {
+        return switch (modell.getJournalStatus() != null ? modell.getJournalStatus().getKode() : "") {
+            case "J" -> "Journalført";
+            case "MO" -> "Mottatt";
+            case "M" -> "MidlertidigJournalført";
+            case "A" -> "Avbrutt";
+            default -> "MidlertidigJournalført";
+        };
+    }
+}

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/kafka/KafkaRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/kafka/KafkaRestTjeneste.java
@@ -5,7 +5,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/server/src/test/java/no/nav/foreldrepenger/fpmock/server/JournalpostSeraliseringDeseraliseringsTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/fpmock/server/JournalpostSeraliseringDeseraliseringsTest.java
@@ -1,0 +1,51 @@
+package no.nav.foreldrepenger.fpmock.server;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.DokumentModell;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.DokumentVariantInnhold;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.JournalpostBruker;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.JournalpostModell;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Arkivfiltype;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Arkivtema;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.BrukerType;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.DokumentTilknyttetJournalpost;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Dokumentkategori;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.DokumenttypeId;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Journalposttyper;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Journalstatus;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.Variantformat;
+
+public class JournalpostSeraliseringDeseraliseringsTest extends SerializationTestBase {
+
+    @Test
+    public void DokumentVariantInnholdSeraliseringDeseraliseringTest() {
+        test(lagDokumentVariant());
+    }
+
+    private DokumentVariantInnhold lagDokumentVariant() {
+        return new DokumentVariantInnhold(Arkivfiltype.AXML, Variantformat.ORIGINAL, null);
+    }
+
+    @Test
+    public void DokumentModellSeraliseringDeseraliseringTest() {
+        test(lagDokumentModell());
+    }
+
+    private DokumentModell lagDokumentModell() {
+        return new DokumentModell("12345678", DokumenttypeId.INNTEKTSMELDING, true, "tittel",
+                "brevkode", "innholder her!", DokumentTilknyttetJournalpost.HOVEDDOKUMENT,
+                List.of(lagDokumentVariant()), Dokumentkategori.BREV);
+    }
+
+
+    @Test
+    public void JournalpostModellSeraliseringDeseraliseringTest() {
+        test(new JournalpostModell("123456789", "AR123344566", "Inntekstmelding", List.of(lagDokumentModell()), "test",
+                "sakid", "fagsystemId", Journalstatus.MOTTATT, "kommunikasjonsretning", LocalDateTime.now(), "mottakskanal",
+                Arkivtema.FOR, "journaltilstand", Journalposttyper.INNGAAENDE_DOKUMENT, new JournalpostBruker("12345", BrukerType.FNR)));
+    }
+}

--- a/server/src/test/java/no/nav/foreldrepenger/fpmock/server/SerializationTestBase.java
+++ b/server/src/test/java/no/nav/foreldrepenger/fpmock/server/SerializationTestBase.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.vtp.testmodell.jackson;
+package no.nav.foreldrepenger.fpmock.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import no.nav.foreldrepenger.vtp.testmodell.util.JacksonObjectMapperTestscenario;
+import no.nav.foreldrepenger.vtp.server.ApplicationConfig;
 
 public class SerializationTestBase {
 
@@ -19,7 +19,7 @@ public class SerializationTestBase {
 
     @BeforeAll
     public static void beforeAll() {
-        mapper = JacksonObjectMapperTestscenario.getObjectMapper();
+        mapper = new ApplicationConfig.JacksonConfigResolver().getContext(ObjectMapper.class);
     }
 
     protected static void test(Object obj) {


### PR DESCRIPTION
Nye endepunkte oppretter journalpost gitt en journalpostmodell.
Hvis det sendes en inntektsmelding så tar den i tillegg og trigger en journalføringhendelse på kafka.
Utvider journalpostbuilderen for omgjøring av lokalt journalpost object til journalpost object som returneres i SAF-mock. 