### PR TITLE
Revert "Bump graphql-codegen-maven-plugin from 4.0.1 to 4.1.1 (#654)"

### DIFF
--- a/mocks/pdl-mock/pom.xml
+++ b/mocks/pdl-mock/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>io.github.kobylynskyi</groupId>
             <artifactId>graphql-codegen-maven-plugin</artifactId>
-            <version>4.1.1</version>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>io.github.kobylynskyi</groupId>
                 <artifactId>graphql-codegen-maven-plugin</artifactId>
-                <version>4.1.1</version>
+                <version>4.0.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/mocks/saf-mock/pom.xml
+++ b/mocks/saf-mock/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>io.github.kobylynskyi</groupId>
                 <artifactId>graphql-codegen-maven-plugin</artifactId>
-                <version>4.1.1</version>
+                <version>4.0.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This reverts commit 98c56f1ad36f1342080fa340ae92a75ae4495ebc.