### PR TITLE
TFP-4839: Legger til mock for pesys harUføretrygd

### DIFF
--- a/mocks/pesys-mock/pom.xml
+++ b/mocks/pesys-mock/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>mocks</artifactId>
+        <groupId>no.nav.foreldrepenger.vtp</groupId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pesys-mock</artifactId>
+    <name>VTP ::pesys-mock</name>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jaxrs</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/PesysMock.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/PesysMock.java
@@ -1,0 +1,65 @@
+package no.nav.mock.pesys;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+import no.nav.foreldrepenger.vtp.testmodell.personopplysning.VoksenModell;
+import no.nav.foreldrepenger.vtp.testmodell.repo.TestscenarioRepository;
+import no.nav.mock.pesys.dto.HentUforehistorikkResponseDto;
+import no.nav.mock.pesys.dto.UforeTypeCtiDto;
+import no.nav.mock.pesys.dto.UforehistorikkDto;
+import no.nav.mock.pesys.dto.UforeperiodeDto;
+import no.nav.mock.pesys.dto.UføreTypeCode;
+
+@Path("/api/pesys")
+public class PesysMock {
+
+    private static final String HEADER_FNR = "fnr";
+
+    @Context
+    private TestscenarioRepository testscenarioRepository;
+
+    public PesysMock() {
+    }
+
+    public PesysMock(TestscenarioRepository testscenarioRepository) {
+        this.testscenarioRepository = testscenarioRepository;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public HentUforehistorikkResponseDto hentUføreHistorikk(@HeaderParam(HEADER_FNR) String fnr) {
+        var personIndeks = testscenarioRepository.getPersonIndeks();
+        VoksenModell voksenModell = personIndeks.finnByIdent(fnr);
+        if (voksenModell.harUføretrygd()) {
+            return lagUføreResponseMedEffektFom5ÅrSiden();
+        } else {
+            return new HentUforehistorikkResponseDto(new UforehistorikkDto(List.of()));
+        }
+
+
+
+    }
+
+    protected HentUforehistorikkResponseDto lagUføreResponseMedEffektFom5ÅrSiden() {
+        return new HentUforehistorikkResponseDto(
+                new UforehistorikkDto(List.of(
+                        new UforeperiodeDto(100,
+                                LocalDate.now().minusYears(5),
+                                LocalDate.now().minusYears(5),
+                                new UforeTypeCtiDto(UføreTypeCode.UFORE),
+                                LocalDate.now().minusYears(5),
+                                LocalDate.now().minusYears(5))
+                ))
+        );
+    }
+}

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/PesysMock.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/PesysMock.java
@@ -1,6 +1,8 @@
 package no.nav.mock.pesys;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
@@ -23,6 +25,7 @@ import no.nav.mock.pesys.dto.UføreTypeCode;
 public class PesysMock {
 
     private static final String HEADER_FNR = "fnr";
+    private static final Date FEM_ÅR_SIDEN = convertToDateViaInstant(LocalDate.now().minusYears(5));
 
     @Context
     private TestscenarioRepository testscenarioRepository;
@@ -45,21 +48,20 @@ public class PesysMock {
         } else {
             return new HentUforehistorikkResponseDto(new UforehistorikkDto(List.of()));
         }
-
-
-
     }
 
     protected HentUforehistorikkResponseDto lagUføreResponseMedEffektFom5ÅrSiden() {
         return new HentUforehistorikkResponseDto(
                 new UforehistorikkDto(List.of(
-                        new UforeperiodeDto(100,
-                                LocalDate.now().minusYears(5),
-                                LocalDate.now().minusYears(5),
-                                new UforeTypeCtiDto(UføreTypeCode.UFORE),
-                                LocalDate.now().minusYears(5),
-                                LocalDate.now().minusYears(5))
+                        new UforeperiodeDto(100, FEM_ÅR_SIDEN, FEM_ÅR_SIDEN,
+                                new UforeTypeCtiDto(UføreTypeCode.UFORE), FEM_ÅR_SIDEN, FEM_ÅR_SIDEN)
                 ))
         );
+    }
+
+    private static Date convertToDateViaInstant(LocalDate dateToConvert) {
+        return java.util.Date.from(dateToConvert.atStartOfDay()
+                .atZone(ZoneId.systemDefault())
+                .toInstant());
     }
 }

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/HentUforehistorikkResponseDto.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/HentUforehistorikkResponseDto.java
@@ -1,0 +1,4 @@
+package no.nav.mock.pesys.dto;
+
+public record HentUforehistorikkResponseDto(UforehistorikkDto uforehistorikk) {
+}

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforeTypeCtiDto.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforeTypeCtiDto.java
@@ -1,0 +1,4 @@
+package no.nav.mock.pesys.dto;
+
+public record UforeTypeCtiDto(UføreTypeCode code) {
+}

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforehistorikkDto.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforehistorikkDto.java
@@ -1,0 +1,7 @@
+package no.nav.mock.pesys.dto;
+
+import java.util.List;
+
+public record UforehistorikkDto(List<UforeperiodeDto> uføreperiodeListe) {
+
+}

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforeperiodeDto.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforeperiodeDto.java
@@ -1,11 +1,11 @@
 package no.nav.mock.pesys.dto;
 
-import java.time.LocalDate;
+import java.util.Date;
 
 public record UforeperiodeDto(Integer uforegrad,
-                              LocalDate uforetidspunkt,
-                              LocalDate virk,
+                              Date uforetidspunkt,
+                              Date virk,
                               UforeTypeCtiDto uforetype,
-                              LocalDate ufgFom,
-                              LocalDate ufgTom) {
+                              Date ufgFom,
+                              Date ufgTom) {
 }

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforeperiodeDto.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UforeperiodeDto.java
@@ -1,0 +1,11 @@
+package no.nav.mock.pesys.dto;
+
+import java.time.LocalDate;
+
+public record UforeperiodeDto(Integer uforegrad,
+                              LocalDate uforetidspunkt,
+                              LocalDate virk,
+                              UforeTypeCtiDto uforetype,
+                              LocalDate ufgFom,
+                              LocalDate ufgTom) {
+}

--- a/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UføreTypeCode.java
+++ b/mocks/pesys-mock/src/main/java/no/nav/mock/pesys/dto/UføreTypeCode.java
@@ -1,0 +1,24 @@
+package no.nav.mock.pesys.dto;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
+public enum UføreTypeCode {
+    @JsonEnumDefaultValue
+    UKJENT,
+    /**
+     * Uføre
+     */
+    UFORE,
+    /**
+     * Uføre m/yrkesskade
+     */
+    UF_M_YRKE,
+    /**
+     * Første virkningsdato, ikke ufør
+     */
+    VIRK_IKKE_UFOR,
+    /**
+     * Yrkesskade
+     */
+    YRKE;
+}

--- a/mocks/pesys-mock/src/test/java/no/nav/mock/pesys/HentUforeHistorikkResponseSeraliseringTest.java
+++ b/mocks/pesys-mock/src/test/java/no/nav/mock/pesys/HentUforeHistorikkResponseSeraliseringTest.java
@@ -1,0 +1,52 @@
+package no.nav.mock.pesys;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.foreldrepenger.vtp.testmodell.personopplysning.AnnenPartModell;
+import no.nav.foreldrepenger.vtp.testmodell.personopplysning.BrukerModell;
+import no.nav.foreldrepenger.vtp.testmodell.personopplysning.PersonIndeks;
+import no.nav.foreldrepenger.vtp.testmodell.personopplysning.SøkerModell;
+import no.nav.foreldrepenger.vtp.testmodell.repo.TestscenarioRepository;
+
+@ExtendWith(MockitoExtension.class)
+class HentUforeHistorikkResponseSeraliseringTest {
+    private static final String FNR = "22222233333";
+
+    @Mock
+    private TestscenarioRepository testscenarioRepository;
+    @Mock
+    private PersonIndeks personIndeks;
+
+    private PesysMock pesysMock;
+
+
+    @BeforeEach
+    void PesysMockInit() {
+        when(testscenarioRepository.getPersonIndeks()).thenReturn(personIndeks);
+        pesysMock = new PesysMock(testscenarioRepository);
+    }
+
+    @Test
+    void sjekkEnPeriodeNårHarUføretrygTrue() {
+        var søkerModell = new SøkerModell(FNR, "Tester", LocalDate.now().minusYears(25), true, BrukerModell.Kjønn.M);
+        when(personIndeks.finnByIdent(any())).thenReturn(søkerModell);
+        assertThat(pesysMock.hentUføreHistorikk(FNR).uforehistorikk().uføreperiodeListe().size()).isEqualTo(1);
+    }
+
+    @Test
+    void sjekkTomPeriodeNårHarUføretrygFalse() {
+        var annenPartModell = new AnnenPartModell(FNR, "Tester", LocalDate.now().minusYears(25), false, BrukerModell.Kjønn.M);
+        when(personIndeks.finnByIdent(any())).thenReturn(annenPartModell);
+        assertThat(pesysMock.hentUføreHistorikk(FNR).uforehistorikk().uføreperiodeListe().size()).isEqualTo(0);
+    }
+}

--- a/mocks/pom.xml
+++ b/mocks/pom.xml
@@ -35,6 +35,7 @@
         <module>infotrygd-paaroerende-sykdom-mock</module>
         <module>omsorgspenger-rammemeldinger-mock</module>
         <module>skjermet-person-mock</module>
+        <module>pesys-mock</module>
     </modules>
 
     <dependencyManagement>

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/AnnenPartModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/AnnenPartModell.java
@@ -16,8 +16,8 @@ public class AnnenPartModell extends VoksenModell {
     public AnnenPartModell() {
     }
 
-    public AnnenPartModell(String lokalIdent, String navn, LocalDate fødselsdato, Kjønn kjønn) {
-        super(lokalIdent, navn, fødselsdato, kjønn);
+    public AnnenPartModell(String lokalIdent, String navn, LocalDate fødselsdato, boolean harUføretrygd, Kjønn kjønn) {
+        super(lokalIdent, navn, fødselsdato, harUføretrygd, kjønn);
     }
 
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/SøkerModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/SøkerModell.java
@@ -11,8 +11,8 @@ public class SøkerModell extends VoksenModell {
     public SøkerModell() {
     }
 
-    public SøkerModell(String lokalIdent, String navn, LocalDate fødselsdato, Kjønn kjønn) {
-        super(lokalIdent, navn, fødselsdato, kjønn);
+    public SøkerModell(String lokalIdent, String navn, LocalDate fødselsdato, boolean harUføretrygd, Kjønn kjønn) {
+        super(lokalIdent, navn, fødselsdato, harUføretrygd, kjønn);
     }
 
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/VoksenModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/VoksenModell.java
@@ -2,14 +2,24 @@ package no.nav.foreldrepenger.vtp.testmodell.personopplysning;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public abstract class VoksenModell extends PersonModell {
+
+    @JsonProperty("harUføretrygd")
+    private boolean harUføretrygd;
 
     public VoksenModell() {
     }
 
-    public VoksenModell(String lokalIdent, String navn, LocalDate fødselsdato, Kjønn kjønn) {
+    public VoksenModell(String lokalIdent, String navn, LocalDate fødselsdato, boolean harUføretrygd, Kjønn kjønn) {
         super(lokalIdent, navn, fødselsdato);
+        this.harUføretrygd = harUføretrygd;
         setKjønn(kjønn);
+    }
+
+    public boolean harUføretrygd() {
+        return harUføretrygd;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -456,6 +456,11 @@
             </dependency>
             <dependency>
                 <groupId>no.nav.foreldrepenger.vtp</groupId>
+                <artifactId>pesys-mock</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.foreldrepenger.vtp</groupId>
                 <artifactId>saf-mock</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -109,6 +109,10 @@
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.vtp</groupId>
+            <artifactId>pesys-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.vtp</groupId>
             <artifactId>testmodell</artifactId>
         </dependency>
         <dependency>

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfig.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfig.java
@@ -55,6 +55,7 @@ import no.nav.foreldrepenger.vtp.server.selftest.IsAliveImpl;
 import no.nav.foreldrepenger.vtp.server.selftest.IsReadyImpl;
 import no.nav.infotrygdpaaroerendesykdom.rest.PårørendeSykdomMock;
 import no.nav.medl2.rest.api.v1.MedlemskapsunntakMock;
+import no.nav.mock.pesys.PesysMock;
 import no.nav.nom.SkjermetPersonMock;
 import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingKonsistensTjeneste;
 import no.nav.omsorgspenger.rammemeldinger.OmsorgspengerMock;
@@ -116,6 +117,7 @@ public class ApplicationConfig extends Application {
         classes.add(DigitalKontaktinformasjonMock.class);
         classes.add(AxsysEnhetstilgangMock.class);
         classes.add(SkjermetPersonMock.class);
+        classes.add(PesysMock.class);
 
         // tekniske ting
         classes.add(OpenAMRestService.class);


### PR DESCRIPTION
Testscenarioefilene kan utvides med "harUføretrygd".
Dette settes i personopplysning.json under søker eller annenPart. 
Her kan du sette harUføretrygd til 'true' eller 'false' eller ingenting (defaulter til false")

Hvis den er satt til true så blir det returnert en enkel periode som har FOM 5 år tilbake i tid.
Hvis den er satt til false så blir det returnert en tom periode.