### PR TITLE
Fix: Sikrer at graphql-java-codegen tilsvarer codegen maven plugin.

### DIFF
--- a/mocks/pdl-mock/pom.xml
+++ b/mocks/pdl-mock/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>graphql-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.kobylynskyi</groupId>
-            <artifactId>graphql-codegen-maven-plugin</artifactId>
-            <version>${graphql-codegen-maven-plugin.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.distelli.graphql</groupId>
             <artifactId>graphql-apigen-deps</artifactId>
             <version>${apigen.version}</version>
@@ -39,6 +34,10 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java-extended-scalars</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.kobylynskyi</groupId>
+            <artifactId>graphql-java-codegen</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -55,7 +54,6 @@
             <plugin>
                 <groupId>io.github.kobylynskyi</groupId>
                 <artifactId>graphql-codegen-maven-plugin</artifactId>
-                <version>${graphql-codegen-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/mocks/pom.xml
+++ b/mocks/pom.xml
@@ -38,6 +38,10 @@
         <module>fpwsproxy-mock</module>
     </modules>
 
+    <properties>
+        <graphql-java-codegen.version>5.7.1</graphql-java-codegen.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -50,6 +54,11 @@
                         <artifactId>okhttp</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.github.kobylynskyi</groupId>
+                <artifactId>graphql-java-codegen</artifactId>
+                <version>${graphql-java-codegen.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -67,6 +76,16 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.github.kobylynskyi</groupId>
+                    <artifactId>graphql-codegen-maven-plugin</artifactId>
+                    <version>${graphql-java-codegen.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/mocks/saf-mock/pom.xml
+++ b/mocks/saf-mock/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>io.github.kobylynskyi</groupId>
                 <artifactId>graphql-codegen-maven-plugin</artifactId>
-                <version>5.6.0</version>
                 <executions>
                     <execution>
                         <id>saf</id>


### PR DESCRIPTION
Kan fjernes deretter fra fp-bom