### PR TITLE
Utvide EREG-navn med sammensattnavn

### DIFF
--- a/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonResponse.java
+++ b/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonResponse.java
@@ -116,6 +116,8 @@ public class OrganisasjonResponse {
     }
 
     static class Navn {
+        @JsonProperty("sammensattnavn")
+        private String sammensattnavn; // NAV-tillegg. Kildedata har opptil 5 navnelinjer.
         @JsonProperty("navnelinje1")
         private String navnelinje1;
         @JsonProperty("navnelinje2")
@@ -152,6 +154,7 @@ public class OrganisasjonResponse {
                 svar.navnelinje4 = navn.navnelinje()[3];
             if (max > 4)
                 svar.navnelinje5 = navn.navnelinje()[4];
+            svar.sammensattnavn = svar.getNavn();
             return svar;
         }
     }


### PR DESCRIPTION
Ser for meg at vi foretrekker navnelinje1..5 som kommer fra kilden i Brønnøysund.
Tar med sammensattnavn i tilfelle noen faller for fristelsen til å bruke det.