### PR TITLE
Flyttet jetty over til 12. Obs på endring i jetty pakker.

### DIFF
--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/identer/FoedselsnummerGenerator.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/identer/FoedselsnummerGenerator.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Objects;
 import java.util.Random;
 
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/GateadresseModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/GateadresseModell.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.vtp.testmodell.personopplysning;
 import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GateadresseModell extends AdresseModell {
     private String gatenavn;
@@ -18,7 +19,19 @@ public class GateadresseModell extends AdresseModell {
     }
 
     @JsonCreator
-    public GateadresseModell(LocalDate fom, LocalDate tom, Endringstype endringstype, LocalDate endringstidspunkt, AdresseType adresseType, Landkode land, String matrikkelId, String gatenavn, Integer gatenummer, String husbokstav, Integer husnummer, String postnummer, String kommunenummer) {
+    public GateadresseModell(@JsonProperty("fom") LocalDate fom,
+                             @JsonProperty("tom") LocalDate tom,
+                             @JsonProperty("endringstype") Endringstype endringstype,
+                             @JsonProperty("endringstidspunkt") LocalDate endringstidspunkt,
+                             @JsonProperty("adresseType") AdresseType adresseType,
+                             @JsonProperty("land") Landkode land,
+                             @JsonProperty("matrikkelId") String matrikkelId,
+                             @JsonProperty("gatenavn")  String gatenavn,
+                             @JsonProperty("gatenummer") Integer gatenummer,
+                             @JsonProperty("husbokstav") String husbokstav,
+                             @JsonProperty("husnummer") Integer husnummer,
+                             @JsonProperty("postnummer") String postnummer,
+                             @JsonProperty("kommunenummer") String kommunenummer) {
         super(fom, tom, endringstype, endringstidspunkt, adresseType, land, matrikkelId);
         this.gatenavn = gatenavn;
         this.gatenummer = gatenummer;

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/Personopplysninger.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/Personopplysninger.java
@@ -45,6 +45,9 @@ public class Personopplysninger {
     @JacksonInject
     private VariabelContainer vars;
 
+    public Personopplysninger() {
+    }
+
     public Personopplysninger(SøkerModell søker,
                               AnnenPartModell annenPart,
                               List<FamilierelasjonModell> familierelasjoner,

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/PostboksadresseModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/PostboksadresseModell.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.vtp.testmodell.personopplysning;
 import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class PostboksadresseModell extends AdresseModell {
     private String postboksnummer;
@@ -15,8 +16,16 @@ public class PostboksadresseModell extends AdresseModell {
     }
 
     @JsonCreator
-    public PostboksadresseModell(LocalDate fom, LocalDate tom, Endringstype endringstype, LocalDate endringstidspunkt, AdresseType adresseType, Landkode land, String matrikkelId,
-                                 String postboksnummer, String poststed, String postboksanlegg) {
+    public PostboksadresseModell(@JsonProperty("fom") LocalDate fom,
+                                 @JsonProperty("tom") LocalDate tom,
+                                 @JsonProperty("endringstype") Endringstype endringstype,
+                                 @JsonProperty("endringstidspunkt") LocalDate endringstidspunkt,
+                                 @JsonProperty("adresseType") AdresseType adresseType,
+                                 @JsonProperty("land") Landkode land,
+                                 @JsonProperty("matrikkelId") String matrikkelId,
+                                 @JsonProperty("postboksnummer") String postboksnummer,
+                                 @JsonProperty("poststed") String poststed,
+                                 @JsonProperty("postboksanlegg") String postboksanlegg) {
         super(fom, tom, endringstype, endringstidspunkt, adresseType, land, matrikkelId);
         this.postboksnummer = postboksnummer;
         this.poststed = poststed;

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/UstrukturertAdresseModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/personopplysning/UstrukturertAdresseModell.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.vtp.testmodell.personopplysning;
 import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class UstrukturertAdresseModell extends AdresseModell {
     private String adresseLinje1;
@@ -18,7 +19,19 @@ public class UstrukturertAdresseModell extends AdresseModell {
     }
 
     @JsonCreator
-    public UstrukturertAdresseModell(LocalDate fom, LocalDate tom, Endringstype endringstype, LocalDate endringstidspunkt, AdresseType adresseType, Landkode land, String matrikkelId, String adresseLinje1, String adresseLinje2, String adresseLinje3, String adresseLinje4, String postNr, String poststed) {
+    public UstrukturertAdresseModell(@JsonProperty("fom") LocalDate fom,
+                                     @JsonProperty("tom") LocalDate tom,
+                                     @JsonProperty("endringstype") Endringstype endringstype,
+                                     @JsonProperty("endringstidspunkt") LocalDate endringstidspunkt,
+                                     @JsonProperty("adresseType") AdresseType adresseType,
+                                     @JsonProperty("land") Landkode land,
+                                     @JsonProperty("matrikkelId") String matrikkelId,
+                                     @JsonProperty("adresseLinje1") String adresseLinje1,
+                                     @JsonProperty("adresseLinje2") String adresseLinje2,
+                                     @JsonProperty("adresseLinje3") String adresseLinje3,
+                                     @JsonProperty("adresseLinje4") String adresseLinje4,
+                                     @JsonProperty("postNr") String postNr,
+                                     @JsonProperty("poststed") String poststed) {
         super(fom, tom, endringstype, endringstidspunkt, adresseType, land, matrikkelId);
         this.adresseLinje1 = adresseLinje1;
         this.adresseLinje2 = adresseLinje2;

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,6 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>no.nav.foreldrepenger.felles</groupId>
-        <artifactId>fp-bom</artifactId>
-        <version>1.0.0</version>
-    </parent>
-
     <groupId>no.nav.foreldrepenger.vtp</groupId>
     <artifactId>vtp</artifactId>
     <packaging>pom</packaging>
@@ -33,7 +27,15 @@
 
     <properties>
         <java.version>17</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <argLine>-Xms256m -Dlog.level.no.nav=WARN -Dfile.encoding=${project.build.sourceEncoding}</argLine>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
 
+        <!-- Sonar felles -->
+        <sonar.organization>navikt</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
         <sonar.projectName>vtp</sonar.projectName>
         <sonar.projectKey>navikt_vtp</sonar.projectKey>
@@ -42,11 +44,22 @@
         <fp-kontrakter.version>7.0.0</fp-kontrakter.version>
 
         <!--    Eksterne avhengigheter    -->
-
         <swagger-codegen-maven-plugin.version>3.0.46</swagger-codegen-maven-plugin.version> <!-- > 3.0.41 har bug med slf4.. -->
         <graphql-java.version>21.1</graphql-java.version>
         <graphql-scalar-java.version>21.0</graphql-scalar-java.version>
         <avro.version>1.11.2</avro.version>
+        <kafka.version>3.5.1</kafka.version>
+
+        <!-- Java Enterprise -->
+        <jakarta.jakartaee-bom.version>10.0.0</jakarta.jakartaee-bom.version>
+        <logstash.version>7.4</logstash.version>
+        <jetty.version>12.0.1</jetty.version>
+        <jersey.version>3.1.3</jersey.version>
+        <slf4j.version>2.0.9</slf4j.version>
+        <logback.version>1.4.11</logback.version>
+
+        <swagger.version>2.2.15</swagger.version>
+        <mockito.version>5.5.0</mockito.version>
     </properties>
 
     <repositories>
@@ -63,16 +76,101 @@
 
     <dependencyManagement>
         <dependencies>
-
+            <!-- Jakarta EE API BOM -->
             <dependency>
-                <groupId>no.nav.foreldrepenger.felles</groupId>
-                <artifactId>fp-bom</artifactId>
-                <version>1.0.0</version>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-bom</artifactId>
+                <version>${jakarta.jakartaee-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
 
+            <!-- Jackson BOM -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.15.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- Jetty BOM -->
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-bom</artifactId>
+                <version>${jetty.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- Jersey BOM -->
+            <dependency>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
+                <version>${jersey.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <!-- Swagger starter-->
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-jaxrs2-jakarta</artifactId>
+                <version>${swagger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations-jakarta</artifactId>
+                <version>${swagger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-core-jakarta</artifactId>
+                <version>${swagger.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.logstash.logback</groupId>
+                <artifactId>logstash-logback-encoder</artifactId>
+                <version>${logstash.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.13.0</version>
+            </dependency>
+
             <!-- Kafka -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka_2.12</artifactId>
@@ -300,33 +398,188 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
         <!--    TEST    -->
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.6.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.11.0</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                        <encoding>UTF-8</encoding>
+                        <release>${java.version}</release>
+                        <parameters>true</parameters>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.16.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.3.0</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.1.2</version>
+                    <configuration>
+                        <!-- Må ha @{argLine} ellers blir properties satt av jacoco-maven-plugin overkrevet -->
+                        <argLine>@{argLine} ${argLine}</argLine>
+                    </configuration>
+                </plugin>
+                <!-- Kjører Databaseskjemainitialisering ved testing fra kommandolinja -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.10</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/*no/nav*/**Test.class</exclude>
+                            <exclude>*.xml</exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report-generate</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report-aggregate</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report-aggregate</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.5.0</version>
+                    <configuration>
+                        <flattenMode>bom</flattenMode>
+                        <flattenedPomFilename>.flattened</flattenedPomFilename>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>flatten</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>flatten.clean</id>
+                            <phase>clean</phase>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>3.9.1.2184</version>
+                </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
@@ -376,8 +629,57 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>sonar</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <distributionManagement>
         <repository>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -134,20 +134,12 @@
             <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-annotations</artifactId>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-http-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/MockServer.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/MockServer.java
@@ -11,14 +11,12 @@ import java.util.logging.LogManager;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.HandlerContainer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
-import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,14 +64,10 @@ public class MockServer {
         server = new Server();
         setConnectors(server);
 
-        //var contextHandlerCollection = new ContextHandlerCollection();
-        //server.setHandler(contextHandlerCollection);
-
         ldapServer = new LdapServer(new File(KeystoreUtils.getKeystoreFilePath()), KeystoreUtils.getKeyStorePassword().toCharArray());
         var kafkaBrokerPort = Integer.parseInt(System.getProperty("kafkaBrokerPort", "9092"));
         var zookeeperPort = Integer.parseInt(System.getProperty("zookeeper.port", "2181"));
         kafkaServer = new LocalKafkaServer(zookeeperPort, kafkaBrokerPort, getBootstrapTopics());
-
     }
 
     public static void main(String[] args) throws Exception {
@@ -109,14 +103,12 @@ public class MockServer {
         var gsakRepo = new GsakRepo();
         var journalRepository = JournalRepositoryImpl.getInstance();
 
-        var handler = (HandlerContainer) server.getHandler();
-
-        addRestServices(testScenarioRepository, instance, gsakRepo, journalRepository, handler);
+        addRestServices(testScenarioRepository, instance, gsakRepo, journalRepository);
 
         startServer();
     }
 
-    private void addRestServices(DelegatingTestscenarioRepository testScenarioRepository, TestscenarioRepositoryImpl instance, GsakRepo gsakRepo, JournalRepositoryImpl journalRepository, HandlerContainer handler) {
+    private void addRestServices(DelegatingTestscenarioRepository testScenarioRepository, TestscenarioRepositoryImpl instance, GsakRepo gsakRepo, JournalRepositoryImpl journalRepository) {
         var config = new ApplicationConfigJersey()
                 .setup(testScenarioRepository,
                         instance,


### PR DESCRIPTION
Testet lokalt.

@JsonCreator krever at ekstra annoteringer settes på parameterne siden man ikke kan aksessere parameter navn over reflection ved runtime.

Jetty 12 krever en import av spesiele EE10 pakker fra 
  ```
    <!-- Jetty BOM -->
    <dependency>
        <groupId>org.eclipse.jetty.ee10</groupId>
        <artifactId>jetty-ee10-bom</artifactId>
        <version>${jetty.version}</version>
        <scope>import</scope>
        <type>pom</type>
    </dependency>
```

Det ser ut at jetty 12 skal støtte både EE8, EE9 og EE10.