### PR TITLE
Test kjøring med distroless java17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM ghcr.io/navikt/fp-baseimages/java:17
+FROM gcr.io/distroless/java17-debian11:nonroot
 
 LABEL org.opencontainers.image.source=https://github.com/navikt/vtp
 
-RUN mkdir lib
+ENV JAVA_OPTS "-Dlogback.configurationFile=/app/logback.xml -XX:MaxRAMPercentage=75.0 -Dfile.encoding=UTF-8 -Duser.timezone=Europe/Oslo"
 
-ENV JAVA_OPTS "-Dlogback.configurationFile=logback.xml -XX:MaxRAMPercentage=75.0 -Dfile.encoding=UTF-8 -Duser.timezone=Europe/Oslo"
+WORKDIR /app
 
-COPY server/target/lib/*.jar ./lib/
 COPY server/kafkasecurity.conf ./
 COPY server/src/main/resources/logback.xml ./
 COPY server/target/app.jar ./
+COPY server/target/lib/*.jar ./lib/
+
+CMD ["/app/app.jar"]


### PR DESCRIPTION
Dette er ikke en prod ting - men kan være en bra test. Om det virker greit - foreslår jeg at vi bare innfører det samme for fp-api, fp-oversikt, og de andre java apper som kjører på GCP.