### PR TITLE
Utvidelse av saf/selv-skjema: navn for avsender/mottaker

### DIFF
--- a/mocks/saf-mock/src/main/java/no/nav/saf/JournalpostSelvbetjeningBuilder.java
+++ b/mocks/saf-mock/src/main/java/no/nav/saf/JournalpostSelvbetjeningBuilder.java
@@ -37,7 +37,7 @@ public final class JournalpostSelvbetjeningBuilder {
         var journalposttype = Journalposttype.valueOf(modell.getJournalposttype().getKode());
         builder.setJournalposttype(journalposttype);
 
-        var avsenderMottaker = new AvsenderMottaker(modell.getAvsenderMottaker().getIdent(), AvsenderMottakerIdType.FNR);
+        var avsenderMottaker = new AvsenderMottaker(modell.getAvsenderMottaker().getIdent(), AvsenderMottakerIdType.FNR, "Navn");
         if (journalposttype == Journalposttype.I) {
             builder.setAvsender(avsenderMottaker);
         } else {

--- a/mocks/saf-mock/src/main/resources/schemas/safselvbetjening.graphqls
+++ b/mocks/saf-mock/src/main/resources/schemas/safselvbetjening.graphqls
@@ -132,6 +132,9 @@ type AvsenderMottaker {
 
     # Identifikatortypen til parten som er avsender eller mottaker av dokumentene på journalposten.
     type: AvsenderMottakerIdType!
+
+    # Navnet til parten som er avsender eller mottaker av dokumentene på journalposten.
+    navn: String!
 }
 
 # Metadata tilknyttet et bestemt dokument i Joark (evt til flere varianter av samme dokument).


### PR DESCRIPTION
Finner ikke helt ut hvilke apps som evt bruker saf-selvbetjening - kan dere utvide evt steder som bruker den?