### PR TITLE
Legg til støtte for opphørt organisasjon

### DIFF
--- a/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonNoekkelinfo.java
+++ b/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonNoekkelinfo.java
@@ -38,6 +38,11 @@ public class OrganisasjonNoekkelinfo {
                 && !modell.organisasjonDetaljer().forretningsadresser().isEmpty()) {
             this.adresse = modell.organisasjonDetaljer().forretningsadresser().get(0);
         }
+
+        if (modell.organisasjonDetaljer() != null
+                && modell.organisasjonDetaljer().opphoersdato() != null) {
+            this.opphoersdato = modell.organisasjonDetaljer().opphoersdato().toString();
+        }
     }
 
     public AdresseEReg getAdresse() {

--- a/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonResponse.java
+++ b/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonResponse.java
@@ -50,6 +50,9 @@ public class OrganisasjonResponse {
         if (modell.organisasjonDetaljer() != null && modell.organisasjonDetaljer().postadresser() != null) {
             this.organisasjonDetaljer.postadresser = modell.organisasjonDetaljer().postadresser();
         }
+        if (modell.organisasjonDetaljer() != null && modell.organisasjonDetaljer().opphoersdato() != null) {
+            this.organisasjonDetaljer.opphoersdato = modell.organisasjonDetaljer().opphoersdato();
+        }
     }
 
     public String getOrganisasjonsnummer() {

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/organisasjon/OrganisasjonDetaljerModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/organisasjon/OrganisasjonDetaljerModell.java
@@ -11,5 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public record OrganisasjonDetaljerModell(LocalDate registreringsDato,
                                          LocalDate datoSistEndret,
                                          List<AdresseEReg> forretningsadresser,
-                                         List<AdresseEReg> postadresser) {
+                                         List<AdresseEReg> postadresser,
+                                         LocalDate opphoersdato) {
 }
+

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/scenario/mapper/OrganisasjonsmodellMapper.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/scenario/mapper/OrganisasjonsmodellMapper.java
@@ -67,6 +67,7 @@ public class OrganisasjonsmodellMapper {
                         organisasjonsdetaljer.registreringsdato(),
                         organisasjonsdetaljer.datoSistEndret(),
                         null,
+                        null,
                         null
                 ));
     }
@@ -81,6 +82,7 @@ public class OrganisasjonsmodellMapper {
                 new OrganisasjonDetaljerModell(
                         organisasjonsdetaljer.registreringsdato(),
                         organisasjonsdetaljer.datoSistEndret(),
+                        null,
                         null,
                         null
                 ));


### PR DESCRIPTION
## Bakgrunn
Vi har behov for å lage scenarioer med en opphørt organisasjon.

## Løsning
Legg til `opphoersdato` på `OrganisasjonDetaljerModell`.