### PR TITLE
Fix: Journalføring av en NAV_NO inntektsmelding fører til at en SAF kafka hensese blir trigget

### DIFF
--- a/mocks/journalpost-mock/pom.xml
+++ b/mocks/journalpost-mock/pom.xml
@@ -18,6 +18,14 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.vtp</groupId>
+            <artifactId>kafka-embedded-mock</artifactId>
+        </dependency>
+        <dependency>
+            <artifactId>teamdokumenthandtering-avro-schemas</artifactId>
+            <groupId>no.nav.teamdokumenthandtering</groupId>
+        </dependency>
     </dependencies>
 
 	<build>

--- a/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalforingHendelseSender.java
+++ b/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalforingHendelseSender.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.vtp.server.api.journalforing.hendelse;
+package no.nav.dokarkiv;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -54,6 +54,9 @@ public class JournalforingHendelseSender {
     }
 
     private BehandlingsTema tilBehandlingsTema(JournalpostModell modell) {
+        if (modell.getBehandlingTema() != null) {
+            return BehandlingsTema.fraKode(modell.getBehandlingTema());
+        }
         return switch (modell.getDokumentModellList().isEmpty() ? DokumenttypeId.UDEFINERT : modell.getDokumentModellList().getFirst().getDokumentType()) {
             case SØKNAD_SVANGERSKAPSPENGER -> BehandlingsTema.SVANGERSKAPSPENGER;
             case SØKNAD_FORELDREPENGER_ADOPSJON -> BehandlingsTema.FORELDREPENGER_ADOPSJON;

--- a/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMapper.java
+++ b/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMapper.java
@@ -51,6 +51,7 @@ public class JournalpostMapper {
         modell.setEksternReferanseId(journalpostRequest.getEksternReferanseId());
         modell.setMottakskanal(Mottakskanal.fraKode(journalpostRequest.getKanal()));
         modell.setJournalStatus(erKnyttetTilSak(journalpostRequest.getSak()) ? Journalstatus.JOURNALFØRT : Journalstatus.MOTTATT);
+        modell.setBehandlingTema(journalpostRequest.getBehandlingstema());
         return modell;
     }
 

--- a/mocks/saf-mock/src/main/java/no/nav/saf/JournalpostBuilder.java
+++ b/mocks/saf-mock/src/main/java/no/nav/saf/JournalpostBuilder.java
@@ -65,6 +65,7 @@ public class JournalpostBuilder {
                     new RelevantDato(mottatt, Datotype.DATO_JOURNALFOERT),
                     new RelevantDato(mottatt, Datotype.DATO_REGISTRERT)));
         }
+        journalpost.setBehandlingstema(modell.getBehandlingTema());
        return journalpost;
     }
 

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
@@ -35,6 +35,7 @@ public class JournalpostModell {
     private String journaltilstand;
     private Journalposttyper journalposttype;
     private JournalpostBruker bruker;
+    private String behandlingTema;
 
     public JournalpostModell() {
     }
@@ -54,7 +55,8 @@ public class JournalpostModell {
                              @JsonProperty("arkivtema") Arkivtema arkivtema,
                              @JsonProperty("journaltilstand") String journaltilstand,
                              @JsonProperty("journalposttype") Journalposttyper journalposttype,
-                             @JsonProperty("bruker") JournalpostBruker bruker) {
+                             @JsonProperty("bruker") JournalpostBruker bruker,
+                             @JsonProperty("behandlingTema") String behandlingTema) {
         this.journalpostId = journalpostId;
         this.eksternReferanseId = eksternReferanseId;
         this.tittel = tittel;
@@ -70,6 +72,7 @@ public class JournalpostModell {
         this.journaltilstand = journaltilstand;
         this.journalposttype = journalposttype;
         this.bruker = bruker;
+        this.behandlingTema = behandlingTema;
     }
 
     public String getJournalpostId() {
@@ -194,6 +197,13 @@ public class JournalpostModell {
         this.bruker = bruker;
     }
 
+    public String getBehandlingTema() {
+        return behandlingTema;
+    }
+
+    public void setBehandlingTema(String behandlingTema) {
+        this.behandlingTema = behandlingTema;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/JournalforingRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/journalforing/JournalforingRestTjeneste.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import no.nav.foreldrepenger.vtp.kafkaembedded.LocalKafkaProducer;
-import no.nav.foreldrepenger.vtp.server.api.journalforing.hendelse.JournalforingHendelseSender;
+import no.nav.dokarkiv.JournalforingHendelseSender;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.JournalpostModellGenerator;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.JournalforingResultatDto;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.JournalpostModell;

--- a/server/src/test/java/no/nav/foreldrepenger/fpmock/server/JournalpostSeraliseringDeseraliseringsTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/fpmock/server/JournalpostSeraliseringDeseraliseringsTest.java
@@ -3,6 +3,8 @@ package no.nav.foreldrepenger.fpmock.server;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.BehandlingsTema;
+
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.DokumentModell;
@@ -47,6 +49,7 @@ public class JournalpostSeraliseringDeseraliseringsTest extends SerializationTes
     public void JournalpostModellSeraliseringDeseraliseringTest() {
         test(new JournalpostModell("123456789", "AR123344566", "Inntekstmelding", List.of(lagDokumentModell()), "test",
                 "sakid", "fagsystemId", Journalstatus.MOTTATT, "kommunikasjonsretning", LocalDateTime.now(), Mottakskanal.ALTINN,
-                Arkivtema.FOR, "journaltilstand", Journalposttyper.INNGAAENDE_DOKUMENT, new JournalpostBruker("12345", BrukerType.FNR)));
+                Arkivtema.FOR, "journaltilstand", Journalposttyper.INNGAAENDE_DOKUMENT, new JournalpostBruker("12345", BrukerType.FNR),
+                BehandlingsTema.FORELDREPENGER.getOffisiellKode()));
     }
 }


### PR DESCRIPTION
Denne endringen gjør at man trigger en kafka hendelse på `teamdokumenthandtering.aapen-dok-journalfoering` etter en ny IM blir journalført i dokarkiv fra selvbetjent inntektsmelding. Denne meldingen blir da konsumert av `fordel` som igjen leser journalposten - knytter den til riktig sak, ferdigstiller og så sender den inn til fagsystemet.

Det blir veldig likt til dette som faktisk skjer i verdikjeden.