### PR TITLE
feat: Legger om entra token grupper til å være den samme oid på tværs av entra og msgraph api.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # The MIT License
 
-Copyright 2019 NAV (Arbeids- og velferdsdirektoratet) - The Norwegian Labour and Welfare Administration
+Copyright 2019 Nav (Arbeids- og velferdsdirektoratet) - The Norwegian Labour and Welfare Administration
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Virtuell Tjeneste Plattform (VTP)
 - Team Foreldrepenger <teamforeldrepenger(at)nav.no>
 - Team Sykdom-i-familien
 
-## For NAV-ansatte
+## For Nav-ansatte
 Interne henvendelser kan sendes via Slack i kanalen #vtp-chatten
 
 ## Teknologi som må installeres

--- a/mocks/ldap-mock/src/main/java/no/nav/foreldrepenger/vtp/ldap/LdapServer.java
+++ b/mocks/ldap-mock/src/main/java/no/nav/foreldrepenger/vtp/ldap/LdapServer.java
@@ -27,7 +27,7 @@ import com.unboundid.ldif.LDIFChangeRecord;
 import com.unboundid.ldif.LDIFReader;
 
 import no.nav.foreldrepenger.vtp.testmodell.ansatt.AnsatteIndeks;
-import no.nav.foreldrepenger.vtp.testmodell.ansatt.NAVAnsatt;
+import no.nav.foreldrepenger.vtp.testmodell.ansatt.NavAnsatt;
 import no.nav.foreldrepenger.vtp.testmodell.repo.impl.BasisdataProviderFileImpl;
 
 public class LdapServer {
@@ -56,16 +56,16 @@ public class LdapServer {
 
         directoryServer = new InMemoryDirectoryServer(cfg);
         readLdifFilesFromClasspath();
-        readNAVAnsatte();
+        readNavAnsatte();
     }
 
-    private void readNAVAnsatte() throws LDAPException {
-        for (NAVAnsatt navAnsatt : ansattIndeks.alleAnsatte()) {
+    private void readNavAnsatte() throws LDAPException {
+        for (NavAnsatt navAnsatt : ansattIndeks.alleAnsatte()) {
             addNavAnsatt(navAnsatt);
         }
     }
 
-    private void addNavAnsatt(NAVAnsatt navAnsatt) throws LDAPException {
+    private void addNavAnsatt(NavAnsatt navAnsatt) throws LDAPException {
         var entry = new Entry(
                 String.format("CN=%s,OU=Users,OU=NAV,OU=BusinessUnits,DC=test,DC=local", navAnsatt.ident()),
                 new Attribute("objectClass", "user", "organizationalPerson", "person", "top"),
@@ -85,7 +85,7 @@ public class LdapServer {
 
     }
 
-    private static List<String> tilMemberOf(List<NAVAnsatt.NAVGroup> grupper) {
+    private static List<String> tilMemberOf(List<NavAnsatt.NavGroup> grupper) {
         return grupper.stream()
                 .map(gruppe -> String.format("CN=%s,OU=AccountGroups,OU=Groups,OU=NAV,OU=BusinessUnits,DC=test,DC=local", gruppe.name()))
                 .toList();

--- a/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonResponse.java
+++ b/mocks/organisasjon-mock/src/main/java/no/nav/tjeneste/virksomhet/organisasjon/rs/OrganisasjonResponse.java
@@ -120,7 +120,7 @@ public class OrganisasjonResponse {
 
     static class Navn {
         @JsonProperty("sammensattnavn")
-        private String sammensattnavn; // NAV-tillegg. Kildedata har opptil 5 navnelinjer.
+        private String sammensattnavn; // Nav-tillegg. Kildedata har opptil 5 navnelinjer.
         @JsonProperty("navnelinje1")
         private String navnelinje1;
         @JsonProperty("navnelinje2")

--- a/mocks/pdl-mock/src/main/resources/schemas/pdl.graphqls
+++ b/mocks/pdl-mock/src/main/resources/schemas/pdl.graphqls
@@ -713,8 +713,8 @@ type Endring {
     registrertAv: String!
     # Hvilke system endringen har kommet fra (f.eks srvXXX). Denne blir satt til "FREG" for det vi får fra Folkeregisteret.
     systemkilde: String!
-    # Opphavet til informasjonen. I NAV blir dette satt i forbindelse med registrering (f.eks: Sykehuskassan).
-    # Fra Folkeregisteret får vi opphaven til dems opplysning, altså NAV, UDI, Politiet, Skatteetaten o.l.. Fra Folkeregisteret kan det også være tekniske navn som: DSF_MIGRERING, m.m..
+    # Opphavet til informasjonen. I Nav blir dette satt i forbindelse med registrering (f.eks: Sykehuskassan).
+    # Fra Folkeregisteret får vi opphaven til dems opplysning, altså Nav, UDI, Politiet, Skatteetaten o.l.. Fra Folkeregisteret kan det også være tekniske navn som: DSF_MIGRERING, m.m..
     kilde: String!
 
     hendelseId:String!

--- a/mocks/saf-mock/src/main/resources/schemas/saf.graphqls
+++ b/mocks/saf-mock/src/main/resources/schemas/saf.graphqls
@@ -21,7 +21,7 @@ input BrukerIdInput {
 
 # Indikator på hvilken type id som brukes i spørringen.
 enum BrukerIdType {
-    # NAV aktørid for en person.
+    # Nav aktørid for en person.
     AKTOERID
 
     # Folkeregisterets fødselsnummer eller d-nummer for en person.
@@ -255,18 +255,18 @@ type Journalpost {
     # Landet forsendelsen er mottatt fra eller sendt til. Feltet skal i utgangspunktet kun være populert dersom avsender eller mottaker er en institusjon med adresse i utlandet.
     avsenderMottakerLand: String @deprecated(reason: "Feltet er deprekert og vil bli fjernet i fremtiden. Bruk avsenderMottaker.land i stedet.")
 
-    # NAV-enheten som har journalført forsendelsen. I noen tilfeller brukes journalfEnhet til å rute journalføringsoppgaven til korrekt enhet i NAV. I slike tilfeller vil journalfEnhet være satt også for ikke-journalførte dokumenter.
+    # Nav-enheten som har journalført forsendelsen. I noen tilfeller brukes journalfEnhet til å rute journalføringsoppgaven til korrekt enhet i Nav. I slike tilfeller vil journalfEnhet være satt også for ikke-journalførte dokumenter.
     journalforendeEnhet: String  @deprecated(reason: "Feltet er deprekert og vil bli fjernet i fremtiden. Bruk journalfoerendeEnhet i stedet.")
 
-    # NAV-enheten som har journalført forsendelsen. I noen tilfeller brukes journalfEnhet til å rute journalføringsoppgaven til korrekt enhet i NAV. I slike tilfeller vil journalfEnhet være satt også for ikke-journalførte dokumenter.
+    # Nav-enheten som har journalført forsendelsen. I noen tilfeller brukes journalfEnhet til å rute journalføringsoppgaven til korrekt enhet i Nav. I slike tilfeller vil journalfEnhet være satt også for ikke-journalførte dokumenter.
     journalfoerendeEnhet: String
 
-    # Personen eller systembrukeren i NAV som har journalført forsendelsen.
-    # * Bruken av feltet varierer, og kan inneholde den ansattes navn eller NAV-ident. Dersom forsendelsen er automatisk journalført, kan innholdet være f.eks. en servicebruker eller et batchnavn.
+    # Personen eller systembrukeren i Nav som har journalført forsendelsen.
+    # * Bruken av feltet varierer, og kan inneholde den ansattes navn eller Nav-ident. Dersom forsendelsen er automatisk journalført, kan innholdet være f.eks. en servicebruker eller et batchnavn.
     journalfortAvNavn: String
 
-    # Personen eller systembrukeren i NAV som har opprettet journalposten.
-    # * Bruken av feltet varierer, og kan inneholde den ansattes navn eller NAV-ident. For inngående dokumenter kan innholdet være f.eks. en servicebruker eller et batchnavn.
+    # Personen eller systembrukeren i Nav som har opprettet journalposten.
+    # * Bruken av feltet varierer, og kan inneholde den ansattes navn eller Nav-ident. For inngående dokumenter kan innholdet være f.eks. en servicebruker eller et batchnavn.
     opprettetAvNavn: String
 
     # Kanalen dokumentene ble mottatt i eller sendt ut på f.eks. "SENTRAL_UTSKRIFT" eller "ALTINN".
@@ -285,7 +285,7 @@ type Journalpost {
     # Liste over datoer som kan være relevante for denne journalposten, f.eks. DATO_EKSPEDERT. Hvilke relevante datoer som returneres, avhenger av journalposttypen.
     relevanteDatoer: [RelevantDato]
 
-    # Antall ganger brevet har vært forsøkt sendt til bruker og deretter kommet i retur til NAV. Vil kun være satt for utgående forsendelser.
+    # Antall ganger brevet har vært forsøkt sendt til bruker og deretter kommet i retur til Nav. Vil kun være satt for utgående forsendelser.
     antallRetur: String
 
     # Brukes for sporing og feilsøking på tvers av systemer.
@@ -323,7 +323,7 @@ type RelevantDato {
     datotype: Datotype!
 }
 
-# En sak i NAV har flere saksnumre (fagsaksnummer og arkivsaksnummer).
+# En sak i Nav har flere saksnumre (fagsaksnummer og arkivsaksnummer).
 # * Fagsaken viser til saken slik denne er definert i et fagsystem. Saken identifiseres ved fagsakId + fagsaksystem.
 # * Arkivsaksnummer er "skyggesaken" som man tradisjonelt har journalført mot i Joark. Denne skal nå anses som en intern nøkkel i Joark.
 ##
@@ -356,7 +356,7 @@ type Sak {
     tema: Tema
 }
 
-# Person eller organisasjon som har et forhold til NAV, f.eks. som mottaker av tjenester eller ytelser.
+# Person eller organisasjon som har et forhold til Nav, f.eks. som mottaker av tjenester eller ytelser.
 type Bruker {
     # Brukerens identifikator. For personbrukere returneres personens aktørID eller fødselsnummer. For organisasjonsbrukere returneres et organisasjonsnummer.
     id: String
@@ -483,7 +483,7 @@ type DokumentInfo {
     tittel: String
 
     # Kode som sier noe om dokumentets innhold og oppbygning.
-    # * For inngående skjema er brevkoden normalt en NAV-skjemaID f.eks. *"NAV 14-05.09"*. Enkelte vedlegg har en vedleggskode som sier noe om innholdet.
+    # * For inngående skjema er brevkoden normalt en Nav-skjemaID f.eks. *"Nav 14-05.09"*. Enkelte vedlegg har en vedleggskode som sier noe om innholdet.
     # * For utgående dokumenter sier brevkoden noe om hvilken dokumentmal som er benyttet og hvordan dokumentet skal distribueres.
     brevkode: String
 
@@ -575,7 +575,7 @@ enum Datotype {
     # * Returneres for alle journalposttyper
     DATO_JOURNALFOERT
 
-    # * Tidspunkt dokumentene i journalposten ble registrert i NAV sine systemer.
+    # * Tidspunkt dokumentene i journalposten ble registrert i Nav sine systemer.
     # * Returneres for inngående journalposter
     DATO_REGISTRERT
 
@@ -596,7 +596,7 @@ enum Datotype {
 # Indikerer hvor man kan finne saksparten som dokumentene er journalført mot, samt en peker til selve fagsaken, dersom det finnes en.
 # * For pensjons- og uføresaker vil arkivsaksystemet være PSAK. For alle andre sakstyper er arkivsaksystem GSAK.
 enum Arkivsaksystem {
-    # Arkivsaksystem for alle NAV saker unntatt pensjon og uføre.
+    # Arkivsaksystem for alle Nav saker unntatt pensjon og uføre.
     GSAK
 
     # Arkivsaksystem for pensjon og uføre.
@@ -605,13 +605,13 @@ enum Arkivsaksystem {
 
 # Sier hvorvidt journalposten er et inngående dokument, et utgående dokument eller et notat.
 enum Journalposttype {
-    # **Inngående dokument** - Dokumentasjon som NAV har mottatt fra en ekstern part. De fleste inngående dokumenter er søknader, ettersendelser av dokumentasjon til sak, eller innsendinger fra arbeidsgivere. Meldinger brukere har sendt til "Skriv til NAV" arkiveres også som inngående dokumenter..
+    # **Inngående dokument** - Dokumentasjon som Nav har mottatt fra en ekstern part. De fleste inngående dokumenter er søknader, ettersendelser av dokumentasjon til sak, eller innsendinger fra arbeidsgivere. Meldinger brukere har sendt til "Skriv til Nav" arkiveres også som inngående dokumenter..
     I
 
-    # **Unngående dokument** - Dokumentasjon som NAV har produsert og sendt ut til en ekstern part. De fleste utgående dokumenter er informasjons- eller vedtaksbrev til privatpersoner eller organisasjoner. "Skriv til NAV"-meldinger som saksbehandlere har sendt til brukere arkiveres også som utgående dokumenter.
+    # **Unngående dokument** - Dokumentasjon som Nav har produsert og sendt ut til en ekstern part. De fleste utgående dokumenter er informasjons- eller vedtaksbrev til privatpersoner eller organisasjoner. "Skriv til Nav"-meldinger som saksbehandlere har sendt til brukere arkiveres også som utgående dokumenter.
     U
 
-    # **Notat** - Dokumentasjon som NAV har produsert selv, uten at formålet er å distribuere dette ut av NAV. Eksempler på notater er samtalereferater med veileder på kontaktsenter og interne forvaltningsnotater.
+    # **Notat** - Dokumentasjon som Nav har produsert selv, uten at formålet er å distribuere dette ut av Nav. Eksempler på notater er samtalereferater med veileder på kontaktsenter og interne forvaltningsnotater.
     N
 }
 
@@ -708,7 +708,7 @@ enum Kanal {
     # * Brukes for inngående, utgående journalposter og notater.
     SKAN_NETS
 
-    # Forsendelsen er sendt inn på papir og skannet på NAVs skanningsenter for pensjon og bidrag.
+    # Forsendelsen er sendt inn på papir og skannet på Navs skanningsenter for pensjon og bidrag.
     # * Brukes for inngående journalposter.
     SKAN_PEN
 
@@ -724,7 +724,7 @@ enum Kanal {
     # * Brukes for inngående og utgående journalposter.
     HELSENETTET
 
-    # Forsendelsen skal ikke distribueres ut av NAV.
+    # Forsendelsen skal ikke distribueres ut av Nav.
     # * Brukes for alle notater og noen utgående journalposter
     INGEN_DISTRIBUSJON
 
@@ -732,10 +732,10 @@ enum Kanal {
     # * Brukes for inngående journalposter
     NAV_NO_UINNLOGGET
 
-    # Bruker har fylt ut og sendt inn dokumentet sammen med en NAV-ansatt. Det er den NAV-ansatte som var pålogget innsendingsløsningen.
+    # Bruker har fylt ut og sendt inn dokumentet sammen med en Nav-ansatt. Det er den Nav-ansatte som var pålogget innsendingsløsningen.
     INNSENDT_NAV_ANSATT
 
-    # Forsendelsen inneholder en komplett chatdialog (inngående og utgående meldinger) mellom en bruker og en veileder i NAV.
+    # Forsendelsen inneholder en komplett chatdialog (inngående og utgående meldinger) mellom en bruker og en veileder i Nav.
     NAV_NO_CHAT
 
     # Brevet er sendt til virksomhet som Taushetsbelagt Post via Altinn.
@@ -746,7 +746,7 @@ enum Kanal {
     # * Brukes for inngående journalposter.
     E_POST
 
-    # Forsendelsen er mottatt i en av NAVs meldingsbokser i Altinn.
+    # Forsendelsen er mottatt i en av Navs meldingsbokser i Altinn.
     # * Brukes for inngående journalposter.
     ALTINN_INNBOKS
 
@@ -755,7 +755,7 @@ enum Kanal {
 }
 
 # Temaet/Fagområdet som en journalpost og tilhørende sak tilhører, f.eks. **FOR** (foreldrepenger).
-# * I NAV brukes Tema for å klassifisere journalposter i arkivet med tanke på gjenfinning, tilgangsstyring og bevaringstid.
+# * I Nav brukes Tema for å klassifisere journalposter i arkivet med tanke på gjenfinning, tilgangsstyring og bevaringstid.
 enum Tema {
     # Arbeidsavklaringspenger
     AAP

--- a/mocks/saf-mock/src/main/resources/schemas/safselvbetjening.graphqls
+++ b/mocks/saf-mock/src/main/resources/schemas/safselvbetjening.graphqls
@@ -147,7 +147,7 @@ type DokumentInfo {
     tittel: String
 
     # Kode som sier noe om dokumentets innhold og oppbygning.
-    # * For inngående skjema er brevkoden normalt en NAV-skjemaID f.eks. *"NAV 14-05.09"*. Enkelte vedlegg har en vedleggskode som sier noe om innholdet.
+    # * For inngående skjema er brevkoden normalt en Nav-skjemaID f.eks. *"Nav 14-05.09"*. Enkelte vedlegg har en vedleggskode som sier noe om innholdet.
     # * For utgående dokumenter sier brevkoden noe om hvilken dokumentmal som er benyttet og hvordan dokumentet skal distribueres.
     brevkode: String
 
@@ -185,13 +185,13 @@ type Dokumentvariant {
 
 # Sier hvorvidt journalposten er et inngående dokument, et utgående dokument eller et notat.
 enum Journalposttype {
-    # **Inngående dokument** - Dokumentasjon som NAV har mottatt fra en ekstern part. De fleste inngående dokumenter er søknader, ettersendelser av dokumentasjon til sak, eller innsendinger fra arbeidsgivere. Meldinger brukere har sendt til "Skriv til NAV" arkiveres også som inngående dokumenter..
+    # **Inngående dokument** - Dokumentasjon som Nav har mottatt fra en ekstern part. De fleste inngående dokumenter er søknader, ettersendelser av dokumentasjon til sak, eller innsendinger fra arbeidsgivere. Meldinger brukere har sendt til "Skriv til Nav" arkiveres også som inngående dokumenter..
     I
 
-    # **Unngående dokument** - Dokumentasjon som NAV har produsert og sendt ut til en ekstern part. De fleste utgående dokumenter er informasjons- eller vedtaksbrev til privatpersoner eller organisasjoner. "Skriv til NAV"-meldinger som saksbehandlere har sendt til brukere arkiveres også som utgående dokumenter.
+    # **Unngående dokument** - Dokumentasjon som Nav har produsert og sendt ut til en ekstern part. De fleste utgående dokumenter er informasjons- eller vedtaksbrev til privatpersoner eller organisasjoner. "Skriv til Nav"-meldinger som saksbehandlere har sendt til brukere arkiveres også som utgående dokumenter.
     U
 
-    # **Notat** - Dokumentasjon som NAV har produsert selv, uten at formålet er å distribuere dette ut av NAV. Eksempler på notater er samtalereferater med veileder på kontaktsenter og interne forvaltningsnotater.
+    # **Notat** - Dokumentasjon som Nav har produsert selv, uten at formålet er å distribuere dette ut av Nav. Eksempler på notater er samtalereferater med veileder på kontaktsenter og interne forvaltningsnotater.
     N
 }
 
@@ -210,7 +210,7 @@ enum Journalstatus {
     # * Tilsvarer statusen **JOURNALFOERT** for inngående dokumenter.
     FERDIGSTILT
 
-    # Dokumentet er sendt til bruker. Statusen benyttes også når dokumentet er tilgjengeliggjort for bruker på DittNAV, og bruker er varslet.
+    # Dokumentet er sendt til bruker. Statusen benyttes også når dokumentet er tilgjengeliggjort for bruker på DittNav, og bruker er varslet.
     # * Statusen kan forekomme for utgående dokumenter og notater.
     EKSPEDERT
 
@@ -288,7 +288,7 @@ enum Kanal {
     # * Brukes for inngående, utgående journalposter og notater.
     SKAN_NETS
 
-    # Forsendelsen er sendt inn på papir og skannet på NAVs skanningsenter for pensjon og bidrag.
+    # Forsendelsen er sendt inn på papir og skannet på Navs skanningsenter for pensjon og bidrag.
     # * Brukes for inngående journalposter.
     SKAN_PEN
 
@@ -304,7 +304,7 @@ enum Kanal {
     # * Brukes for inngående og utgående journalposter.
     HELSENETTET
 
-    # Forsendelsen skal ikke distribueres ut av NAV.
+    # Forsendelsen skal ikke distribueres ut av Nav.
     # * Brukes for alle notater og noen utgående journalposter
     INGEN_DISTRIBUSJON
 
@@ -312,10 +312,10 @@ enum Kanal {
     # * Brukes for inngående journalposter
     NAV_NO_UINNLOGGET
 
-    # Bruker har fylt ut og sendt inn dokumentet sammen med en NAV-ansatt. Det er den NAV-ansatte som var pålogget innsendingsløsningen.
+    # Bruker har fylt ut og sendt inn dokumentet sammen med en Nav-ansatt. Det er den Nav-ansatte som var pålogget innsendingsløsningen.
     INNSENDT_NAV_ANSATT
 
-    # Forsendelsen inneholder en komplett chatdialog (inngående og utgående meldinger) mellom en bruker og en veileder i NAV.
+    # Forsendelsen inneholder en komplett chatdialog (inngående og utgående meldinger) mellom en bruker og en veileder i Nav.
     NAV_NO_CHAT
 
     # Brevet er sendt til Taushetsbelagt Post via Altinn.
@@ -326,7 +326,7 @@ enum Kanal {
     # * Brukes for inngående journalposter.
     E_POST
 
-    # Forsendelsen er mottatt i en av NAVs meldingsbokser i Altinn.
+    # Forsendelsen er mottatt i en av Navs meldingsbokser i Altinn.
     # * Brukes for inngående journalposter.
     ALTINN_INNBOKS
 
@@ -352,7 +352,7 @@ enum Datotype {
     # * Returneres for alle journalposttyper
     DATO_JOURNALFOERT
 
-    # * Tidspunkt dokumentene i journalposten ble registrert i NAV sine systemer.
+    # * Tidspunkt dokumentene i journalposten ble registrert i Nav sine systemer.
     # * Returneres for inngående journalposter
     DATO_REGISTRERT
 
@@ -400,7 +400,7 @@ enum AvsenderMottakerIdType {
 }
 
 # Temaet/Fagområdet som en journalpost og tilhørende sak tilhører, f.eks. **FOR** (foreldrepenger).
-# * I NAV brukes Tema for å klassifisere journalposter i arkivet med tanke på gjenfinning, tilgangsstyring og bevaringstid.
+# * I Nav brukes Tema for å klassifisere journalposter i arkivet med tanke på gjenfinning, tilgangsstyring og bevaringstid.
 enum Tema {
     # Arbeidsavklaringspenger
     AAP

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/ansatt/AnsatteIndeks.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/ansatt/AnsatteIndeks.java
@@ -7,25 +7,25 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 public class AnsatteIndeks {
 
-    private final Map<String, NAVAnsatt> ansatteByIdent = new ConcurrentHashMap<>();
-    private final Map<UUID, NAVAnsatt> ansatteById = new ConcurrentHashMap<>();
+    private final Map<String, NavAnsatt> ansatteByIdent = new ConcurrentHashMap<>();
+    private final Map<UUID, NavAnsatt> ansatteById = new ConcurrentHashMap<>();
 
-    public void leggTil(List<NAVAnsatt> ansatte) {
+    public void leggTil(List<NavAnsatt> ansatte) {
         ansatte.forEach(ansatt -> {
             this.ansatteByIdent.putIfAbsent(ansatt.ident().toLowerCase(), ansatt);
             this.ansatteById.putIfAbsent(ansatt.oid(), ansatt);
         });
     }
 
-    public Collection<NAVAnsatt> alleAnsatte() {
+    public Collection<NavAnsatt> alleAnsatte() {
         return ansatteByIdent.values();
     }
 
-    public NAVAnsatt findByIdent(String ident) {
+    public NavAnsatt findByIdent(String ident) {
         return ansatteByIdent.get(ident.toLowerCase());
     }
 
-    public NAVAnsatt findById(UUID id) {
+    public NavAnsatt findById(UUID id) {
         return ansatteById.get(id);
     }
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/ansatt/NavAnsatt.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/ansatt/NavAnsatt.java
@@ -1,0 +1,9 @@
+package no.nav.foreldrepenger.vtp.testmodell.ansatt;
+
+import java.util.List;
+import java.util.UUID;
+
+public record NavAnsatt(String ident, UUID oid, String displayName, String givenName, String surname, String email,
+                        String streetAddress, List<NavGroup> groups, List<String> enheter) {
+    public record NavGroup(UUID oid, String name) {}
+}

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/repo/impl/BasisdataProviderFileImpl.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/repo/impl/BasisdataProviderFileImpl.java
@@ -7,7 +7,7 @@ import java.util.Comparator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import no.nav.foreldrepenger.vtp.testmodell.ansatt.AnsatteIndeks;
-import no.nav.foreldrepenger.vtp.testmodell.ansatt.NAVAnsatt;
+import no.nav.foreldrepenger.vtp.testmodell.ansatt.NavAnsatt;
 import no.nav.foreldrepenger.vtp.testmodell.enheter.EnheterIndeks;
 import no.nav.foreldrepenger.vtp.testmodell.enheter.Norg2Modell;
 import no.nav.foreldrepenger.vtp.testmodell.identer.FiktiveFnr;
@@ -109,8 +109,8 @@ public class BasisdataProviderFileImpl implements BasisdataProvider {
 
     private void loadAnsatte() {
         try (var is = getClass().getResourceAsStream(ANSATTE)) {
-            var ansatte = Arrays.asList(mapper.readValue(is, NAVAnsatt[].class));
-            ansatte.sort(Comparator.comparing(NAVAnsatt::ident));
+            var ansatte = Arrays.asList(mapper.readValue(is, NavAnsatt[].class));
+            ansatte.sort(Comparator.comparing(NavAnsatt::ident));
             ansatteIndeks.leggTil(ansatte);
         } catch (IOException e) {
             throwIllegaleStateExecption(ANSATTE, e);

--- a/model/src/main/resources/basedata/nav-ansatte.json
+++ b/model/src/main/resources/basedata/nav-ansatte.json
@@ -1,6 +1,6 @@
 [
     {
-        "ident": "saksbeh",
+        "ident": "S123456",
         "oid": "3c3caafb-a943-4255-aa65-6f29345b7541",
         "displayName": "Sara Saksbehandler",
         "givenName": "Sara",
@@ -37,11 +37,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler" ]
+        ]
     },
     {
-        "ident": "saksbeh6",
+        "ident": "S666666",
         "oid": "05801408-feb8-42b2-850a-8d87adb911c7",
         "displayName": "Sa6a Saksbehandler6",
         "givenName": "Sa6a",
@@ -86,11 +85,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler", "kode6" ]
+        ]
     },
     {
-        "ident": "saksbeh7",
+        "ident": "S777777",
         "oid": "352b0a40-4d13-43e7-8e55-ba6060d6d430",
         "displayName": "Sa7a Saksbehandler7",
         "givenName": "Sa7a",
@@ -135,11 +133,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler", "kode7" ]
+        ]
     },
     {
-        "ident": "saksbha",
+        "ident": "E123456",
         "oid": "98f1a0f3-292e-412c-b84a-d729b6169f2b",
         "displayName": "Ea Saksbehandler",
         "givenName": "Ea",
@@ -184,11 +181,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler", "egenansatt" ]
+        ]
     },
     {
-        "ident": "beslut",
+        "ident": "B123456",
         "oid": "fb864a55-bc42-4196-aba9-792c78661806",
         "displayName": "Birger Beslutter",
         "givenName": "Birger",
@@ -233,11 +229,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler", "beslutter" ]
+        ]
     },
     {
-        "ident": "oversty",
+        "ident": "O123456",
         "oid": "d6881997-05d7-4ff2-8ef6-818d8539c434",
         "displayName": "Ove Overstyrer",
         "givenName": "Ove",
@@ -282,11 +277,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler", "overstyrer" ]
+        ]
     },
     {
-        "ident": "klageb",
+        "ident": "K123456",
         "oid": "cf70667f-250e-4565-a365-75f07f87fe29",
         "displayName": "Klara Klagebehandler",
         "givenName": "Klara",
@@ -327,11 +321,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler" ]
+        ]
     },
     {
-        "ident": "veil",
+        "ident": "V123456",
         "oid": "ba6f0772-b99b-4eb9-857e-7a9e6720d582",
         "displayName": "Vegard Veileder",
         "givenName": "Vegard",
@@ -341,16 +334,8 @@
         "enheter": [],
         "groups": [
             {
-                "oid": "eb211c0d-9ca6-467f-8863-9def2cc06fd3",
-                "name": "0000-GA-fpsak-saksbehandler"
-            },
-            {
                 "oid": "edfe14fe-9a34-4ecb-8840-536ac2bc2818",
                 "name": "0000-GA-fpsak-veileder"
-            },
-            {
-                "oid": "5081d7b2-00df-442b-acb5-48eeaa114e96",
-                "name": "0000-GA-k9-saksbehandler"
             },
             {
                 "oid": "79630737-b41d-41eb-93fb-30907e1afed7",
@@ -376,16 +361,15 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "veileder" ]
+        ]
     },
     {
-        "ident": "oppgs",
+        "ident": "L123456",
         "oid": "4cd710cc-c367-4110-8126-fe495ee11c23",
-        "displayName": "Oline Oppgavestyrer",
+        "displayName": "Oline Los-Oppgavestyrer",
         "givenName": "Oline",
-        "surname": "Oppgavestyrer",
-        "email": "oline.oppgavestyrer@example.com",
+        "surname": "Los-Oppgavestyrer",
+        "email": "oline.los-oppgavestyrer@example.com",
         "streetAddress": "4833",
         "enheter": [],
         "groups": [
@@ -425,11 +409,10 @@
                 "oid": "39f2f9c8-1631-438a-a82e-8bed14adb672",
                 "name": "0000-GA-INNTK"
             }
-        ],
-        "vtpgrupper": [ "saksbehandler", "oppgavestyrer" ]
+        ]
     },
     {
-        "ident": "drift",
+        "ident": "D123456",
         "oid": "d3b97fcb-8778-4e09-ba7e-f8993d6e26a6",
         "displayName": "Daniel Drifter",
         "givenName": "Daniel",
@@ -446,11 +429,10 @@
                 "oid": "7ac42b69-14af-479e-9e9c-b2235bea9863",
                 "name": "0000-GA-k9-drift"
             }
-        ],
-        "vtpgrupper": [ "drift", "veileder" ]
+        ]
     },
     {
-        "ident": "pip",
+        "ident": "P123456",
         "oid": "3d48bf40-4bfd-48d8-8280-065bf8ced9cd",
         "displayName": "Policy Information Point",
         "givenName": "Policy Information",
@@ -458,7 +440,6 @@
         "email": "pip@example.com",
         "streetAddress": "2970",
         "enheter": [],
-        "groups": [],
-        "vtpgrupper": [ "pip" ]
+        "groups": []
     }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <!-- NAV Avhengigheter – kontrakt -->
+            <!-- Nav Avhengigheter – kontrakt -->
             <dependency>
                 <groupId>no.nav.foreldrepenger.kontrakter</groupId>
                 <artifactId>fp-ws-proxy-v1</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -133,7 +133,7 @@
             <artifactId>util</artifactId>
         </dependency>
 
-        <!-- NAV biblioteker -->
+        <!-- Nav biblioteker -->
 
         <dependency>
             <groupId>no.nav.teamdokumenthandtering</groupId>

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/AzureAdRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/AzureAdRestTjeneste.java
@@ -44,7 +44,7 @@ import no.nav.foreldrepenger.vtp.server.auth.rest.JsonWebKeyHelper;
 import no.nav.foreldrepenger.vtp.server.auth.rest.Oauth2AccessTokenResponse;
 import no.nav.foreldrepenger.vtp.server.auth.rest.WellKnownResponse;
 import no.nav.foreldrepenger.vtp.testmodell.ansatt.AnsatteIndeks;
-import no.nav.foreldrepenger.vtp.testmodell.ansatt.NAVAnsatt;
+import no.nav.foreldrepenger.vtp.testmodell.ansatt.NavAnsatt;
 import no.nav.foreldrepenger.vtp.testmodell.repo.impl.BasisdataProviderFileImpl;
 
 @Tag(name = "AzureAd")
@@ -120,7 +120,7 @@ public class AzureAdRestTjeneste {
                 if (refreshToken == null) {
                     yield badRequest();
                 }
-                token = createToken(ANSATTE_INDEKS.findByIdent("saksbeh"), nonce);
+                token = createToken(ANSATTE_INDEKS.findByIdent("S123456"), nonce);
                 yield ok(new Oauth2AccessTokenResponse(token)).build();
             }
             default -> {
@@ -144,13 +144,13 @@ public class AzureAdRestTjeneste {
     @Path("/bruker")
     @Produces({MediaType.APPLICATION_JSON})
     @Operation(description = "azureAd/access_token - brukes primært av autotest til å logge inn en saksbehandler programmatisk (uten interaksjon med GUI)")
-    public Response accessToken(@QueryParam("ident") @DefaultValue("saksbeh") String ident) {
+    public Response accessToken(@QueryParam("ident") @DefaultValue("S123456") String ident) {
         var bruker = Optional.ofNullable(ANSATTE_INDEKS.findByIdent(ident)).orElseThrow();
         var token = createToken(bruker, nonceCache.get(NONCE));
         return ok(new Oauth2AccessTokenResponse(token)).build();
     }
 
-    private String createToken(NAVAnsatt bruker, String nonce) {
+    private String createToken(NavAnsatt bruker, String nonce) {
         return AzureOidcTokenGenerator.azureUserToken(bruker, ISSUER, nonce);
     }
 
@@ -217,7 +217,7 @@ public class AzureAdRestTjeneste {
                 .collect(Collectors.joining("\n"));
     }
 
-    private static String leggTilRadITabell(URI location, NAVAnsatt ansatt) {
+    private static String leggTilRadITabell(URI location, NavAnsatt ansatt) {
         var redirectForInnloggingAvAnsatt = fromUri(location).queryParam(CODE, ansatt.ident()).build();
         return String.format("<tr><a href=\"%s\"><h1>%s</h1></a></tr>", redirectForInnloggingAvAnsatt, ansatt.displayName());
     }

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/AzureOidcTokenGenerator.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/AzureOidcTokenGenerator.java
@@ -15,14 +15,11 @@ import org.jose4j.lang.JoseException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import no.nav.foreldrepenger.vtp.server.auth.rest.JsonWebKeyHelper;
-import no.nav.foreldrepenger.vtp.testmodell.ansatt.AnsatteIndeks;
-import no.nav.foreldrepenger.vtp.testmodell.ansatt.NAVAnsatt;
-import no.nav.foreldrepenger.vtp.testmodell.repo.impl.BasisdataProviderFileImpl;
+import no.nav.foreldrepenger.vtp.testmodell.ansatt.NavAnsatt;
 
 
 public final class AzureOidcTokenGenerator {
 
-    private static final AnsatteIndeks ANSATTE_INDEKS = BasisdataProviderFileImpl.getInstance().getAnsatteIndeks();
     private AzureOidcTokenGenerator() {
     }
 
@@ -49,11 +46,11 @@ public final class AzureOidcTokenGenerator {
         }
     }
 
-    public static String azureUserToken(NAVAnsatt bruker, String issuer, String nonce) {
+    public static String azureUserToken(NavAnsatt bruker, String issuer, String nonce) {
         JwtClaims claims = createCommonClaims(bruker.ident(), issuer);
         claims.setStringClaim("oid", bruker.oid().toString());
         claims.setStringClaim("NAVident", bruker.ident());
-        claims.setStringListClaim("groups", bruker.vtpgrupper().stream().toList());
+        claims.setStringListClaim("groups", bruker.groups().stream().map(group -> group.oid().toString()).toList());
 
         if (Objects.nonNull(nonce) && !nonce.isBlank()) {
             claims.setClaim("nonce", nonce);

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/MicrosoftGraphApiMock.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/MicrosoftGraphApiMock.java
@@ -21,7 +21,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import no.nav.foreldrepenger.vtp.testmodell.ansatt.AnsatteIndeks;
-import no.nav.foreldrepenger.vtp.testmodell.ansatt.NAVAnsatt;
+import no.nav.foreldrepenger.vtp.testmodell.ansatt.NavAnsatt;
 import no.nav.foreldrepenger.vtp.testmodell.repo.impl.BasisdataProviderFileImpl;
 
 @Tag(name = "AzureAd")
@@ -70,7 +70,7 @@ public class MicrosoftGraphApiMock {
         return Response.status(Response.Status.UNAUTHORIZED).build();
     }
 
-    private static @NotNull MemberOfResponse opprettMemberOfResponse(NAVAnsatt ansatt) {
+    private static @NotNull MemberOfResponse opprettMemberOfResponse(NavAnsatt ansatt) {
         return new MemberOfResponse("https://graph.microsoft.com/v1.0/$metadata#groups(" + ansatt.displayName() + ")", null,
                 mapTilUserGroupsResponse(ansatt));
     }
@@ -82,7 +82,7 @@ public class MicrosoftGraphApiMock {
         var filterBy = filter.split(" eq ");
         var identifikator = filterBy[1].replace("'", "");
 
-        NAVAnsatt ansatt;
+        NavAnsatt ansatt;
         if (filterBy[0].contains("onPremisesSamAccountName")) {
             ansatt = ANSATTE_INDEKS.findByIdent(identifikator);
         } else {
@@ -112,7 +112,7 @@ public class MicrosoftGraphApiMock {
         return Response.noContent().build();
     }
 
-    private NAVAnsatt getAnsatt(String auth) {
+    private NavAnsatt getAnsatt(String auth) {
         if (!auth.startsWith("Bearer ")) {
             throw new WebApplicationException("Bad mock access token; must be on format Bearer access:<userid>",
                     Response.Status.FORBIDDEN);
@@ -129,11 +129,11 @@ public class MicrosoftGraphApiMock {
         }
     }
 
-    private static List<Group> mapTilUserGroupsResponse(NAVAnsatt ansatt) {
+    private static List<Group> mapTilUserGroupsResponse(NavAnsatt ansatt) {
         return ansatt.groups().stream().map(MicrosoftGraphApiMock::mapTilGroup).toList();
     }
 
-    private static Group mapTilGroup(NAVAnsatt.NAVGroup group) {
+    private static Group mapTilGroup(NavAnsatt.NavGroup group) {
         return new Group(group.oid(), group.name(), group.name());
     }
 


### PR DESCRIPTION
- NAV -> Nav
- Bruker riktig format på saksbehandler Identer (blir enklere der hvor man validerer formatet på identen).

fp-autotest og k9-verdikjede må synces til å bruke de samme identer for programmatisk innlogging av saksbehandlere.

fp-felles må oppdateres med riktige vtp grupper -> https://github.com/navikt/fp-felles/pull/1393