### PR TITLE
Fix: Inntektskomponenten returnerer inntekt for nåværende måned.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY server/target/lib/*.jar ./lib/
 
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 \
     -XX:+PrintCommandLineFlags \
+    -XX:UseSVE=0 \
     -Dfile.encoding=UTF-8 \
     -Duser.timezone=Europe/Oslo \
     -Dlogback.configurationFile=/app/logback.xml"

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/hentinntektlistebolk/modell/HentInntektlisteBolkMapperRest.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/hentinntektlistebolk/modell/HentInntektlisteBolkMapperRest.java
@@ -29,7 +29,7 @@ public class HentInntektlisteBolkMapperRest {
         arbeidsInntektIdent.setArbeidsInntektMaaned(new ArrayList<>());
 
         YearMonth runningMonth = fom;
-        while (runningMonth.isBefore(tom)) {
+        while (runningMonth.isBefore(tom) || runningMonth.equals(tom)) {
             ArbeidsInntektInformasjon arbeidsInntektInformasjon = makeArbeidsInntektInformasjonForMåned(modell, runningMonth,
                     filter82830);
             ArbeidsInntektMaaned arbeidsInntektMaaned = new ArbeidsInntektMaaned();


### PR DESCRIPTION
Det viser seg at inntektskomponent mocken returnerer ikke inntekter for tom måneden. Dette er synlig om man bruker den nye inntektsmelding løsningen som alltid mangler inntekt i siste måned. 

Har testet lokalt med verdikjede og fpsak testene og ting flyr som vanlig. 

@espenjv kunne dere i SiF sjekke om det påvirker deres testene?

@jolarsen jeg legger inn `-XX:UseSVE=0` ved anledning.