### PR TITLE
Publiserer ForelderBarnRelasjon hendelser ved fødselshendelser.

### DIFF
--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/ForelderBarnRelasjonHendelseDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/ForelderBarnRelasjonHendelseDto.java
@@ -1,0 +1,14 @@
+package no.nav.foreldrepenger.vtp.kontrakter;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "FamilierelasjonHendelseDto")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ForelderBarnRelasjonHendelseDto(@Schema String endringstype,
+                                              @Schema String fnr,
+                                              @Schema String relatertPersonsFnr,
+                                              @Schema String relatertPersonsRolle,
+                                              @Schema String minRolleForPerson) implements PersonhendelseDto {
+
+}

--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/PersonhendelseDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/PersonhendelseDto.java
@@ -11,7 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = FødselshendelseDto.class, name = "fødselshendelse"),
         @JsonSubTypes.Type(value = FamilierelasjonHendelseDto.class, name = "familierelasjonshendelse"),
         @JsonSubTypes.Type(value = DødshendelseDto.class, name = "dødshendelse"),
-        @JsonSubTypes.Type(value = DødfødselhendelseDto.class, name = "dødfødselhendelse")
+        @JsonSubTypes.Type(value = DødfødselhendelseDto.class, name = "dødfødselhendelse"),
+        @JsonSubTypes.Type(value = ForelderBarnRelasjonHendelseDto.class, name = "forelderBarnRelasjonHendelse"),
 })
 public interface PersonhendelseDto {
 

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/pdl/PdlLeesahRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/pdl/PdlLeesahRestTjeneste.java
@@ -158,11 +158,11 @@ public class PdlLeesahRestTjeneste {
         if (fødselshendelseDto.fnrMor() != null) {
             // Legg til relasjoner for mor
             leggTilForelderBarnRelasjon(forelderBarnRelasjonHendelseDtos, fødselshendelseDto.endringstype(),
-                    fødselshendelseDto.fnrMor(), barnIdent);
+                    fødselshendelseDto.fnrMor(), barnIdent, "MOR");
         } else if (fødselshendelseDto.fnrFar() != null) {
             // Legg til relasjoner for far
             leggTilForelderBarnRelasjon(forelderBarnRelasjonHendelseDtos, fødselshendelseDto.endringstype(),
-                    fødselshendelseDto.fnrFar(), barnIdent);
+                    fødselshendelseDto.fnrFar(), barnIdent, "FAR");
         }
 
         forelderBarnRelasjonHendelseDtos.forEach(this::produserForelderBarnRelasjonHendelse);
@@ -171,9 +171,9 @@ public class PdlLeesahRestTjeneste {
     private void leggTilForelderBarnRelasjon(List<ForelderBarnRelasjonHendelseDto> dtos,
                                              String endringstype,
                                              String forelderFnr,
-                                             String barnFnr) {
+                                             String barnFnr, String forelderRolle) {
         dtos.add(new ForelderBarnRelasjonHendelseDto(endringstype, forelderFnr, barnFnr, "BARN", "MOR"));
-        dtos.add(new ForelderBarnRelasjonHendelseDto(endringstype, barnFnr, forelderFnr, "MOR", "BARN"));
+        dtos.add(new ForelderBarnRelasjonHendelseDto(endringstype, barnFnr, forelderFnr, forelderRolle, "BARN"));
     }
 
 

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/pdl/PdlLeesahRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/pdl/PdlLeesahRestTjeneste.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.vtp.server.api.pdl;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -26,6 +27,7 @@ import no.nav.foreldrepenger.vtp.kafkaembedded.LocalKafkaProducer;
 import no.nav.foreldrepenger.vtp.kontrakter.DødfødselhendelseDto;
 import no.nav.foreldrepenger.vtp.kontrakter.DødshendelseDto;
 import no.nav.foreldrepenger.vtp.kontrakter.FamilierelasjonHendelseDto;
+import no.nav.foreldrepenger.vtp.kontrakter.ForelderBarnRelasjonHendelseDto;
 import no.nav.foreldrepenger.vtp.kontrakter.FødselshendelseDto;
 import no.nav.foreldrepenger.vtp.kontrakter.PersonhendelseDto;
 import no.nav.foreldrepenger.vtp.testmodell.personopplysning.BarnModell;
@@ -39,6 +41,7 @@ import no.nav.person.pdl.leesah.doedfoedtbarn.DoedfoedtBarn;
 import no.nav.person.pdl.leesah.doedsfall.Doedsfall;
 import no.nav.person.pdl.leesah.familierelasjon.Familierelasjon;
 import no.nav.person.pdl.leesah.foedselsdato.Foedselsdato;
+import no.nav.person.pdl.leesah.forelderbarnrelasjon.ForelderBarnRelasjon;
 
 @Tag(name = "Legge hendelser på PDL topic")
 @Path("/api/pdl/leesah")
@@ -74,16 +77,15 @@ public class PdlLeesahRestTjeneste {
     @Operation(description = "Legg til hendelse")
     public Response leggTilHendelse(PersonhendelseDto personhendelseDto) {
         try {
-            if (personhendelseDto instanceof FødselshendelseDto fødselshendelseDto) {
-                produserFødselshendelse(fødselshendelseDto);
-            } else if (personhendelseDto instanceof DødshendelseDto dødshendelseDto) {
-                produserDødshendelse(dødshendelseDto);
-            } else if (personhendelseDto instanceof DødfødselhendelseDto dødfødselhendelseDto) {
-                produserDødfødselshendelse(dødfødselhendelseDto);
-            } else if (personhendelseDto instanceof FamilierelasjonHendelseDto familierelasjonHendelseDto) {
-                produserFamilierelasjonHendelse(familierelasjonHendelseDto);
-            } else {
-                return Response.status(Response.Status.BAD_REQUEST).entity("{\"error\": \"Ukjent hendelsestype\"}").build();
+            switch (personhendelseDto) {
+                case FødselshendelseDto fødselshendelseDto -> produserFødselshendelse(fødselshendelseDto);
+                case DødshendelseDto dødshendelseDto -> produserDødshendelse(dødshendelseDto);
+                case DødfødselhendelseDto dødfødselhendelseDto -> produserDødfødselshendelse(dødfødselhendelseDto);
+                case FamilierelasjonHendelseDto familierelasjonHendelseDto -> produserFamilierelasjonHendelse(familierelasjonHendelseDto);
+                case ForelderBarnRelasjonHendelseDto forelderBarnRelasjonHendelseDto -> produserForelderBarnRelasjonHendelse(forelderBarnRelasjonHendelseDto);
+                case null, default -> {
+                    return Response.status(Response.Status.BAD_REQUEST).entity("{\"error\": \"Ukjent hendelsestype\"}").build();
+                }
             }
 
         } catch (RuntimeException e) {
@@ -91,6 +93,38 @@ public class PdlLeesahRestTjeneste {
             return Response.status(Response.Status.BAD_REQUEST).entity(String.format("{\"error\": \"%s\"}", e.getMessage())).build();
         }
         return Response.status(201).entity("{\"success\": \"Personhendelse opprettet\"}").build();
+    }
+
+    private void produserForelderBarnRelasjonHendelse(ForelderBarnRelasjonHendelseDto forelderBarnRelasjonHendelseDto) {
+        if (forelderBarnRelasjonHendelseDto == null) {
+            LOG.warn("ForelderBarnRelasjonHendelseDto er null, kan ikke produsere hendelse");
+            return;
+        }
+
+        GenericRecordBuilder personhendelse = new GenericRecordBuilder(Personhendelse.SCHEMA$);
+
+        personhendelse.set(HENDELSE_ID, UUID.randomUUID().toString());
+        personhendelse.set(MASTER_FIELD, "Freg");
+        personhendelse.set(OPPRETTET, LocalDateTime.now().atZone(ZoneId.systemDefault()).toEpochSecond() * 1000);
+        personhendelse.set(OPPLYSNINGSTYPE, "FORELDERBARNRELASJON_V1");
+        personhendelse.set(ENDRINGSTYPE, Endringstype.valueOf(forelderBarnRelasjonHendelseDto.endringstype()));
+
+        String fnr = forelderBarnRelasjonHendelseDto.fnr();
+        personhendelse.set(PERSONIDENTER, List.of(fnr, testscenarioRepository.getPersonIndeks().finnByIdent(fnr).getAktørIdent()));
+
+        if (!Endringstype.ANNULLERT.toString().equals(forelderBarnRelasjonHendelseDto.endringstype())) {
+            GenericRecordBuilder forelderBarnRelasjon = new GenericRecordBuilder(ForelderBarnRelasjon.SCHEMA$);
+            String relatertPersonsFnr = forelderBarnRelasjonHendelseDto.relatertPersonsFnr();
+            forelderBarnRelasjon.set("relatertPersonsIdent", relatertPersonsFnr);
+            forelderBarnRelasjon.set("relatertPersonsRolle", forelderBarnRelasjonHendelseDto.relatertPersonsRolle());
+            forelderBarnRelasjon.set("minRolleForPerson", forelderBarnRelasjonHendelseDto.minRolleForPerson());
+            personhendelse.set("forelderBarnRelasjon", forelderBarnRelasjon.build());
+        }
+
+        LOG.info("Publiserer FORELDERBARNRELASJON_V1 hendelse med minRolle: {}, minFnr: {}, relatertPersonRolle: {}, relatertPersonFnr: {}",
+                forelderBarnRelasjonHendelseDto.minRolleForPerson(), forelderBarnRelasjonHendelseDto.fnr(),
+                forelderBarnRelasjonHendelseDto.relatertPersonsRolle(), forelderBarnRelasjonHendelseDto.relatertPersonsFnr());
+        sendHendelsePåKafka(personhendelse.build());
     }
 
     private void produserFødselshendelse(FødselshendelseDto fødselshendelseDto) {
@@ -113,8 +147,35 @@ public class PdlLeesahRestTjeneste {
             personhendelse.set("foedselsdato", fødselsdato.build());
         }
 
+        LOG.info("Publiserer FOEDSELSDATO_V1 på kafka for barn med ident {}, født: {}", barnIdent, fødselshendelseDto.fødselsdato());
         sendHendelsePåKafka(personhendelse.build());
+
+        produserForelderBarnRelasjon(fødselshendelseDto, barnIdent);
     }
+
+    private void produserForelderBarnRelasjon(FødselshendelseDto fødselshendelseDto, String barnIdent) {
+        List<ForelderBarnRelasjonHendelseDto> forelderBarnRelasjonHendelseDtos = new ArrayList<>();
+        if (fødselshendelseDto.fnrMor() != null) {
+            // Legg til relasjoner for mor
+            leggTilForelderBarnRelasjon(forelderBarnRelasjonHendelseDtos, fødselshendelseDto.endringstype(),
+                    fødselshendelseDto.fnrMor(), barnIdent);
+        } else if (fødselshendelseDto.fnrFar() != null) {
+            // Legg til relasjoner for far
+            leggTilForelderBarnRelasjon(forelderBarnRelasjonHendelseDtos, fødselshendelseDto.endringstype(),
+                    fødselshendelseDto.fnrFar(), barnIdent);
+        }
+
+        forelderBarnRelasjonHendelseDtos.forEach(this::produserForelderBarnRelasjonHendelse);
+    }
+
+    private void leggTilForelderBarnRelasjon(List<ForelderBarnRelasjonHendelseDto> dtos,
+                                             String endringstype,
+                                             String forelderFnr,
+                                             String barnFnr) {
+        dtos.add(new ForelderBarnRelasjonHendelseDto(endringstype, forelderFnr, barnFnr, "BARN", "MOR"));
+        dtos.add(new ForelderBarnRelasjonHendelseDto(endringstype, barnFnr, forelderFnr, "MOR", "BARN"));
+    }
+
 
     public void sendHendelsePåKafka(GenericData.Record rekord) {
         localKafkaProducer.sendMelding(LEESAH_TOPIC, rekord);
@@ -140,6 +201,7 @@ public class PdlLeesahRestTjeneste {
             personhendelse.set("doedsfall", dødsfall.build());
         }
 
+        LOG.info("Publiserer DOEDSFALL_V1 hendelse på kafka for person med ident {}, dødsdato: {}", dødshendelseDto.fnr(), dødshendelseDto.doedsdato());
         sendHendelsePåKafka(personhendelse.build());
     }
 
@@ -163,6 +225,7 @@ public class PdlLeesahRestTjeneste {
             personhendelse.set("doedfoedtBarn", dødfødtBarn.build());
         }
 
+        LOG.info("Publiserer DOEDFOEDT_BARN_V1 hendelse på kafka for barn med ident {}, dødsdato: {}", dødfødselhendelseDto.fnr(), dødfødselhendelseDto.doedfoedselsdato());
         sendHendelsePåKafka(personhendelse.build());
     }
 
@@ -184,6 +247,9 @@ public class PdlLeesahRestTjeneste {
             personhendelse.set("familierelasjon", familierelasjon.build());
         }
 
+        LOG.info("Publiserer FAMILIERELASJON_V1 hendelse med minRolle: {}, minFnr: {}, relatertPersonRolle: {}, relatertPersonFnr: {}",
+                familierelasjonHendelseDto.minRolleForPerson(), familierelasjonHendelseDto.fnr(),
+                familierelasjonHendelseDto.relatertPersonsRolle(), familierelasjonHendelseDto.relatertPersonsFnr());
         sendHendelsePåKafka(personhendelse.build());
     }
 
@@ -226,7 +292,7 @@ public class PdlLeesahRestTjeneste {
         setDødsdatoerIIndeksene(personopplysninger, dødshendelseDto);
     }
 
-    private void setDødsdatoerIIndeksene(Personopplysninger personopplysninger, DødshendelseDto dødshendelseDto){
+    private void setDødsdatoerIIndeksene(Personopplysninger personopplysninger, DødshendelseDto dødshendelseDto) {
         if (dødshendelseDto.fnr().equalsIgnoreCase(personopplysninger.getSøker().getIdent())) {
             personopplysninger.getSøker().setDødsdato(dødshendelseDto.doedsdato());
         } else if (dødshendelseDto.fnr().equalsIgnoreCase(personopplysninger.getAnnenPart().getIdent())) {

--- a/server/src/main/resources/avro/leesah/Personhendelse.avdl
+++ b/server/src/main/resources/avro/leesah/Personhendelse.avdl
@@ -5,6 +5,7 @@ protocol PersonhendelseProto {
   import idl "foedsel/Foedsel.avdl";
   import idl "foedselsdato/Foedselsdato.avdl";
   import idl "familierelasjon/Familierelasjon.avdl";
+  import idl "forelderbarnrelasjon/ForelderBarnRelasjon.avdl";
 
   enum Endringstype {
     OPPRETTET,
@@ -29,5 +30,6 @@ protocol PersonhendelseProto {
     union { null, no.nav.person.pdl.leesah.foedsel.Foedsel } foedsel = null;
     union { null, no.nav.person.pdl.leesah.foedselsdato.Foedselsdato } foedselsdato = null;
     union { null, no.nav.person.pdl.leesah.familierelasjon.Familierelasjon } familierelasjon = null;
+    union { null, no.nav.person.pdl.leesah.forelderbarnrelasjon.ForelderBarnRelasjon } forelderBarnRelasjon = null;
   }
 }

--- a/server/src/main/resources/avro/leesah/forelderbarnrelasjon/ForelderBarnRelasjon.avdl
+++ b/server/src/main/resources/avro/leesah/forelderbarnrelasjon/ForelderBarnRelasjon.avdl
@@ -1,0 +1,11 @@
+/*https://github.com/navikt/pdl/blob/master/libs/contract-pdl-avro/src/main/avro/no/nav/person/pdl/leesah/forelderbarnrelasjon/ForelderBarnRelasjon.avdl*/
+
+@namespace("no.nav.person.pdl.leesah.forelderbarnrelasjon")
+protocol ForelderBarnRelasjonV1 {
+
+	record ForelderBarnRelasjon {
+		union { null, string } relatertPersonsIdent = null;
+		string relatertPersonsRolle;
+		union { null, string } minRolleForPerson = null;
+	}
+}

--- a/server/src/test/java/no/nav/foreldrepenger/fpmock/server/HendelseTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/fpmock/server/HendelseTest.java
@@ -70,7 +70,7 @@ public class HendelseTest {
         assertEquals(4, testscenario.getPersonopplysninger().getFamilierelasjoner().size());
         assertEquals(3, testscenario.getPersonopplysninger().getFamilierelasjonerForAnnenPart().size());
 
-        pdlLeesahRestTjeneste.leggTilHendelse(fødselshendelseDto);
+        pdlLeesahRestTjeneste.leggTilHendelse(fødselshendelseDto, false);
 
         // Henter identen
         var barnIdent = hentUtIdentPåDetSisteBarneSomErRegistert(testscenario.getVariabelContainer());
@@ -93,7 +93,7 @@ public class HendelseTest {
 
         var dødshendelse = new DødshendelseDto(Endringstype.OPPRETTET.name(), null, søkerIdent,dødsdato);
 
-        pdlLeesahRestTjeneste.leggTilHendelse(dødshendelse);
+        pdlLeesahRestTjeneste.leggTilHendelse(dødshendelse, false);
 
         verifiserDødsdatoErSattForFamilierelasjonsmodell(testscenario.getPersonopplysninger().getFamilierelasjoner(), søkerIdent);
         verifiserDødsdatoErSattForFamilierelasjonsmodell(testscenario.getPersonopplysninger().getFamilierelasjonerForAnnenPart(), søkerIdent);
@@ -115,7 +115,7 @@ public class HendelseTest {
         assertEquals(4, testscenario.getPersonopplysninger().getFamilierelasjoner().size());
         assertEquals(3, testscenario.getPersonopplysninger().getFamilierelasjonerForAnnenPart().size());
 
-        pdlLeesahRestTjeneste.leggTilHendelse(dødfødselshendelse);
+        pdlLeesahRestTjeneste.leggTilHendelse(dødfødselshendelse, false);
 
         // Verifiserer riktig format på identen til barn
         var barnIdent = hentUtIdentPåDetSisteBarneSomErRegistert(testscenario.getVariabelContainer());


### PR DESCRIPTION
### **Behov**
Vi trenger å kunne agere på fødselshendelser når en søker får barn ila. saksperiode for ungdomsytelsen.
Dette er for å kunne gjøre en revurdering av behandlingen og gi søker barnetillegg. PDL publiserer dette som ForelderBarnRelasjon hendelser som dokumentert under [livshendelser_pa_kafka](https://pdl-docs.ansatt.nav.no/ekstern/index.html#livshendelser_pa_kafka).

### **Løsning**
Løsningen implementerer både støtte for å publisere disse hendelsene via Rest, men også via eksisterende restkall for fødselshendelser.
For hver fødselshendelse publiseres det to ForelderBarnRelasjon hendelser. En for den ene forelder(mor/far) som subject, og barnet som relatert person, og en for barn som subjekt med forelder(mor/far) som relatert person.

### **Andre endringer**
Legger på ekstra logging når disse hendelsene publiseres i VTP.