### PR TITLE
TFP-6038 kelvin-mock V0

### DIFF
--- a/mocks/kelvin-mock/pom.xml
+++ b/mocks/kelvin-mock/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>mocks</artifactId>
+        <groupId>no.nav.foreldrepenger.vtp</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kelvin-mock</artifactId>
+    <name>VTP ::Kelvin-mock</name>
+    <packaging>jar</packaging>
+
+</project>

--- a/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/ArbeidsavklaringspengerResponse.java
+++ b/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/ArbeidsavklaringspengerResponse.java
@@ -1,0 +1,24 @@
+package no.nav.tjeneste.virksomhet.kelvin;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ArbeidsavklaringspengerResponse(List<AAPVedtak> vedtak) {
+
+    public record AAPVedtak(Integer barnMedStonad, Integer beregningsgrunnlag, Integer dagsats,
+                            String kildesystem, AAPPeriode periode, String saksnummer,
+                            String vedtakId, LocalDateTime vedtaksdato, List<AAPUtbetaling> utbetaling) { }
+
+
+
+    public record AAPPeriode(LocalDate fraOgMedDato, LocalDate tilOgMedDato) {}
+
+    public record AAPUtbetaling(AAPPeriode periode, Integer belop, Integer dagsats,
+                                Integer barnetillegg, AAPReduksjon reduksjon, Integer utbetalingsgrad) {
+    }
+
+    public record AAPReduksjon(Integer annenReduksjon, Integer timerArbeidet) { }
+
+}
+

--- a/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/ArbeidsavklaringspengerResponse.java
+++ b/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/ArbeidsavklaringspengerResponse.java
@@ -1,5 +1,6 @@
 package no.nav.tjeneste.virksomhet.kelvin;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.List;
 public record ArbeidsavklaringspengerResponse(List<AAPVedtak> vedtak) {
 
     public record AAPVedtak(Integer barnMedStonad, Integer beregningsgrunnlag, Integer dagsats,
-                            String kildesystem, AAPPeriode periode, String saksnummer,
+                            Kildesystem kildesystem, AAPPeriode periode, String saksnummer,
                             String vedtakId, LocalDateTime vedtaksdato, List<AAPUtbetaling> utbetaling) { }
 
 
@@ -18,7 +19,11 @@ public record ArbeidsavklaringspengerResponse(List<AAPVedtak> vedtak) {
                                 Integer barnetillegg, AAPReduksjon reduksjon, Integer utbetalingsgrad) {
     }
 
-    public record AAPReduksjon(Integer annenReduksjon, Integer timerArbeidet) { }
+    public record AAPReduksjon(BigDecimal annenReduksjon, BigDecimal timerArbeidet) { }
+
+    public enum Kildesystem {
+        ARENA, KELVIN
+    }
 
 }
 

--- a/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/KelvinMock.java
+++ b/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/KelvinMock.java
@@ -1,7 +1,6 @@
-package no.nav.tjeneste.virksomhet.spokelse.rest;
+package no.nav.tjeneste.virksomhet.kelvin;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -17,16 +16,16 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import no.nav.foreldrepenger.vtp.testmodell.repo.TestscenarioBuilderRepository;
 
-@Tag(name = "Spokelsemock")
-@Path("/spokelse")
-public class SpøkelseMock {
+@Tag(name = "Kelvinmock")
+@Path("/kelvin")
+public class KelvinMock {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SpøkelseMock.class);
-    private static final String LOG_PREFIX = "Spøkelse Rest kall til {}";
+    private static final Logger LOG = LoggerFactory.getLogger(KelvinMock.class);
+    private static final String LOG_PREFIX = "Kevlin Rest kall til {}";
 
     private final TestscenarioBuilderRepository scenarioRepository;
 
-    public SpøkelseMock(@Context TestscenarioBuilderRepository scenarioRepository) {
+    public KelvinMock(@Context TestscenarioBuilderRepository scenarioRepository) {
         this.scenarioRepository = scenarioRepository;
     }
 
@@ -36,12 +35,11 @@ public class SpøkelseMock {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Returnerer sykepenger fra Spøkelse")
-    public SykepengeVedtak[] postSykepenger(PersonRequest personRequest) {
-        // TODO: Utvide IAY-modell med Spøkelse-SP og populere response med data fra testscenario
-        List<SykepengeVedtak> tomrespons = new ArrayList<>();
-        return tomrespons.toArray(SykepengeVedtak[]::new);
+    public ArbeidsavklaringspengerResponse postAAP(PersonRequest personRequest) {
+        // TODO: Utvide IAY-modell med Kelvin-AAP og populere response med data fra testscenario
+        return new ArbeidsavklaringspengerResponse(List.of());
     }
 
-    public record PersonRequest(String fodselsnummer, LocalDate fom) { }
+    public record PersonRequest(String personidentifikator, LocalDate fraOgMedDato, LocalDate tilOgMedDato) { }
 
 }

--- a/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/KelvinMock.java
+++ b/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/KelvinMock.java
@@ -31,10 +31,10 @@ public class KelvinMock {
 
     @SuppressWarnings("unused")
     @POST
-    @Path("/grunnlag")
+    @Path("/maksimum")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Returnerer sykepenger fra Spøkelse")
+    @Operation(description = "Returnerer arbeidsavklaringspenger fra Kelvin og Arena")
     public ArbeidsavklaringspengerResponse postAAP(PersonRequest personRequest) {
         // TODO: Utvide IAY-modell med Kelvin-AAP og populere response med data fra testscenario
         return new ArbeidsavklaringspengerResponse(List.of());

--- a/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/KelvinMock.java
+++ b/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/KelvinMock.java
@@ -21,7 +21,7 @@ import no.nav.foreldrepenger.vtp.testmodell.repo.TestscenarioBuilderRepository;
 public class KelvinMock {
 
     private static final Logger LOG = LoggerFactory.getLogger(KelvinMock.class);
-    private static final String LOG_PREFIX = "Kevlin Rest kall til {}";
+    private static final String LOG_PREFIX = "Kelvin Rest kall til {}";
 
     private final TestscenarioBuilderRepository scenarioRepository;
 

--- a/mocks/pom.xml
+++ b/mocks/pom.xml
@@ -35,6 +35,7 @@
         <module>skjermet-person-mock</module>
         <module>pesys-mock</module>
         <module>spokelse-mock</module>
+        <module>kelvin-mock</module>
         <module>fpwsproxy-mock</module>
         <module>altinn-proxy-mock</module>
         <module>fager-mock</module>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,11 @@
             </dependency>
             <dependency>
                 <groupId>no.nav.foreldrepenger.vtp</groupId>
+                <artifactId>kelvin-mock</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.foreldrepenger.vtp</groupId>
                 <artifactId>fpwsproxy-mock</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -109,6 +109,10 @@
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.vtp</groupId>
+            <artifactId>kelvin-mock</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.vtp</groupId>
             <artifactId>fpwsproxy-mock</artifactId>
         </dependency>
         <dependency>

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfigJersey.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfigJersey.java
@@ -1,5 +1,24 @@
 package no.nav.foreldrepenger.vtp.server;
 
+import static java.util.logging.Level.FINE;
+import static org.glassfish.jersey.logging.LoggingFeature.Verbosity.PAYLOAD_ANY;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.logging.LoggingFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -7,6 +26,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.swagger.v3.oas.integration.GenericOpenApiContextBuilder;
 import io.swagger.v3.oas.integration.OpenApiConfigurationException;
@@ -72,6 +92,7 @@ import no.nav.sigrun.SigrunMock;
 import no.nav.tjeneste.virksomhet.arbeidsfordeling.rest.ArbeidsfordelingRestMock;
 import no.nav.tjeneste.virksomhet.arbeidsforhold.rs.AaregRSV1Mock;
 import no.nav.tjeneste.virksomhet.infotrygd.rest.InfotrygdMock;
+import no.nav.tjeneste.virksomhet.kelvin.KelvinMock;
 import no.nav.tjeneste.virksomhet.organisasjon.rs.OrganisasjonRSV1Mock;
 import no.nav.tjeneste.virksomhet.sak.rs.SakRestMock;
 import no.nav.tjeneste.virksomhet.sak.v1.GsakRepo;
@@ -80,24 +101,6 @@ import no.nav.vtp.DummyRestTjeneste;
 import no.nav.vtp.DummyRestTjenesteBoolean;
 import no.nav.vtp.DummyRestTjenesteFile;
 import no.nav.vtp.hentinntektlistebolk.HentInntektlisteBolkREST;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.logging.LoggingFeature;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static java.util.logging.Level.FINE;
-import static org.glassfish.jersey.logging.LoggingFeature.Verbosity.PAYLOAD_ANY;
 
 @ApplicationPath(ApplicationConfigJersey.API_URI)
 public class ApplicationConfigJersey extends ResourceConfig {
@@ -159,6 +162,7 @@ public class ApplicationConfigJersey extends ResourceConfig {
         classes.add(SkjermetPersonMock.class);
         classes.add(UføreMock.class);
         classes.add(SpøkelseMock.class);
+        classes.add(KelvinMock.class);
         classes.add(FpWsProxyArenaMock.class);
         classes.add(FpWsProxySimuleringOppdragMock.class);
         classes.add(FpWsProxyTilbakekrevingMock.class);


### PR DESCRIPTION
Enkelt rammeverk for å lage en Kelvin-integrasjon i fpabakus som ikke er veldig miljø-avhenging prod/dev/vtp.
Et senere steg er å utvide modellen med Kelvin-AAP slik at man kan lage test-cases - men først må vi forstå responsen og konvensjoner
Se også TFP-6080 for å utvide VTP-modellen med nye sykepenger (nå er de under infotrygd/trex-modellen)