### PR TITLE
Unødvendig dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,10 +314,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Bør ha dep-management - kommer via fp-bom - pga Mockito (er på 1.15) - men trenger ikke dep til bytebuddy