### PR TITLE
TFP-6390 mock for inntektskomp V2

### DIFF
--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektBulkRequest.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektBulkRequest.java
@@ -1,0 +1,10 @@
+package no.nav.vtp.inntektskomponenten;
+
+import java.time.YearMonth;
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record InntektBulkRequest(@NotNull String personident, @NotNull List<String> filter, @NotNull String formaal,
+                                 @NotNull YearMonth maanedFom, @NotNull YearMonth maanedTom) {
+}

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektBulkResponse.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektBulkResponse.java
@@ -1,0 +1,7 @@
+package no.nav.vtp.inntektskomponenten;
+
+import java.util.List;
+
+public record InntektBulkResponse(List<InntektBulk> bulk) {
+    public record InntektBulk(String filter, List<Inntektsinformasjon> data) { }
+}

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektRequest.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektRequest.java
@@ -1,0 +1,9 @@
+package no.nav.vtp.inntektskomponenten;
+
+import java.time.YearMonth;
+
+import jakarta.validation.constraints.NotNull;
+
+public record InntektRequest(@NotNull String personident, @NotNull String filter, @NotNull String formaal,
+                             @NotNull YearMonth maanedFom, @NotNull YearMonth maanedTom) {
+}

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektResponse.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektResponse.java
@@ -1,0 +1,6 @@
+package no.nav.vtp.inntektskomponenten;
+
+import java.util.List;
+
+public record InntektResponse(List<Inntektsinformasjon> data) {
+}

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/Inntektsinformasjon.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/Inntektsinformasjon.java
@@ -1,0 +1,14 @@
+package no.nav.vtp.inntektskomponenten;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+public record Inntektsinformasjon(YearMonth maaned, String opplysningspliktig, String underenhet, String norskident, List<Inntekt> inntektListe) {
+
+    public record Inntekt(String type, BigDecimal beloep, String beskrivelse, String skatteOgAvgiftsregel,
+                          LocalDate opptjeningsperiodeFom, LocalDate opptjeningsperiodeTom, Tilleggsinformasjon tilleggsinformasjon) { }
+
+    public record Tilleggsinformasjon(String type, LocalDate startdato, LocalDate sluttdato) { }
+}

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektskomponentV2REST.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektskomponentV2REST.java
@@ -1,0 +1,78 @@
+package no.nav.vtp.inntektskomponenten;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.InntektYtelseModell;
+import no.nav.foreldrepenger.vtp.testmodell.repo.impl.BasisdataProviderFileImpl;
+import no.nav.foreldrepenger.vtp.testmodell.repo.impl.TestscenarioRepositoryImpl;
+import no.nav.vtp.inntektskomponenten.modell.InntektModellMapper;
+
+
+@Tag(name = "/inntektskomponenten/v2/inntekt")
+@Path("/inntektskomponenten/v2/inntekt")
+public class InntektskomponentV2REST {
+    private static final Logger LOG = LoggerFactory.getLogger(InntektskomponentV2REST.class);
+
+    private final TestscenarioRepositoryImpl testscenarioRepository;
+
+    public InntektskomponentV2REST() {
+        testscenarioRepository = TestscenarioRepositoryImpl.getInstance(BasisdataProviderFileImpl.getInstance());
+    }
+
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Returnerer inntektliste fra Inntektskomponenten")
+    public InntektResponse hentInntektlisteBolk(InntektRequest request) {
+
+        LOG.info("Henter inntekter for: {}", request.personident());
+
+        var imodell = testscenarioRepository.getInntektYtelseModellFraAktørId(request.personident())
+                .map(InntektYtelseModell::inntektskomponentModell);
+        if (imodell.isEmpty()) {
+            return new InntektResponse(List.of());
+        }
+
+        var inntektsinformasjon = InntektModellMapper.makeInntektsinformasjon(
+                imodell.get(), request.maanedFom(), request.maanedTom(), request.filter());
+
+        return new InntektResponse(inntektsinformasjon);
+
+    }
+
+    @POST
+    @Path("/bulk")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Returnerer inntektliste fra Inntektskomponenten")
+    public InntektBulkResponse hentInntektlisteBolk(InntektBulkRequest request) {
+
+        LOG.info("Henter inntekter for: {}", request.personident());
+
+        List<InntektBulkResponse.InntektBulk> bulkinntekter = new ArrayList<>();
+        var imodell = testscenarioRepository.getInntektYtelseModellFraAktørId(request.personident())
+                .map(InntektYtelseModell::inntektskomponentModell);
+        if (imodell.isEmpty()) {
+            return new InntektBulkResponse(List.of());
+        }
+
+        for (var f : request.filter()) {
+            var inntektsinformasjon = InntektModellMapper.makeInntektsinformasjon(
+                    imodell.get(), request.maanedFom(), request.maanedTom(), f);
+            bulkinntekter.add(new InntektBulkResponse.InntektBulk(f, inntektsinformasjon));
+        }
+
+        return new InntektBulkResponse(bulkinntekter);
+
+    }
+
+}

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektskomponentV2REST.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/InntektskomponentV2REST.java
@@ -44,7 +44,7 @@ public class InntektskomponentV2REST {
         }
 
         var inntektsinformasjon = InntektModellMapper.makeInntektsinformasjon(
-                imodell.get(), request.maanedFom(), request.maanedTom(), request.filter());
+                imodell.get(), request.maanedFom(), request.maanedTom(), request.filter(), request.personident());
 
         return new InntektResponse(inntektsinformasjon);
 
@@ -67,7 +67,7 @@ public class InntektskomponentV2REST {
 
         for (var f : request.filter()) {
             var inntektsinformasjon = InntektModellMapper.makeInntektsinformasjon(
-                    imodell.get(), request.maanedFom(), request.maanedTom(), f);
+                    imodell.get(), request.maanedFom(), request.maanedTom(), f, request.personident());
             bulkinntekter.add(new InntektBulkResponse.InntektBulk(f, inntektsinformasjon));
         }
 

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/modell/InntektModellMapper.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/modell/InntektModellMapper.java
@@ -1,0 +1,79 @@
+package no.nav.vtp.inntektskomponenten.modell;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.inntektkomponent.InntektType;
+import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.inntektkomponent.InntektYtelseType;
+import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.inntektkomponent.InntektskomponentModell;
+import no.nav.foreldrepenger.vtp.testmodell.inntektytelse.inntektkomponent.Inntektsperiode;
+import no.nav.vtp.inntektskomponenten.Inntektsinformasjon;
+
+public class InntektModellMapper {
+
+    public static List<Inntektsinformasjon> makeInntektsinformasjon(InntektskomponentModell modell, YearMonth fom, YearMonth tom, String filter) {
+
+        List<Inntektsinformasjon> respons = new ArrayList<>();
+
+        YearMonth runningMonth = fom;
+        while (runningMonth.isBefore(tom) || runningMonth.equals(tom)) {
+            respons.addAll(makeArbeidsInntektInformasjonForMåned(modell, runningMonth, filter));
+            runningMonth = runningMonth.plusMonths(1);
+        }
+
+        return respons;
+    }
+
+    private static List<Inntektsinformasjon> makeArbeidsInntektInformasjonForMåned(InntektskomponentModell modell, YearMonth måned, String filter) {
+        return inntektListeFraModell(modell.getInntektsperioderSplittMånedlig(), måned, filter);
+    }
+
+    private static List<Inntektsinformasjon> inntektListeFraModell(List<Inntektsperiode> modellPeriode, YearMonth måned, String filter) {
+        return modellPeriode.stream()
+                .filter(t -> localDateTimeInYearMonth(t.tom(), måned))
+                .filter(t -> taMedFraInntektsfilter(t, filter))
+                .map(temp -> inntektFraModell(temp, måned))
+                .toList();
+    }
+
+    private static Inntektsinformasjon inntektFraModell(Inntektsperiode ip, YearMonth måned) {
+        var underenhet = ip.orgnr() != null  && !ip.orgnr().isEmpty() ? ip.orgnr() : null;
+        var personag = ip.orgnr() == null  || ip.orgnr().isEmpty() ? ip.arbeidsgiver().getAktørIdent() : null;
+        var inntekt =  new Inntektsinformasjon.Inntekt(fraModellInntektstype(ip.inntektType()), new BigDecimal(ip.beløp()),
+                ip.beskrivelse(), ip.skatteOgAvgiftsregel(), ip.fom(), ip.tom(), null);
+        return new Inntektsinformasjon(måned, null, underenhet, personag, List.of(inntekt));
+    }
+
+    private static boolean taMedFraInntektsfilter(Inntektsperiode p, String filter) {
+        var filter82830 = filter.startsWith("8");
+        if (!filter82830 || p.inntektYtelseType() == null || InntektYtelseType.InntektType.LØNNSINNTEKT.equals(p.inntektYtelseType().getInntektType())) {
+            return true;
+        }
+        if (filter.startsWith("8-28") ||
+                InntektYtelseType.InntektType.PENSJON_ELLER_TRYGD.equals(p.inntektYtelseType().getInntektType()) ||
+                InntektYtelseType.InntektType.NÆRINGSINNTEKT.equals(p.inntektYtelseType().getInntektType())) {
+            return false;
+        }
+        return Set.of(InntektYtelseType.SYKEPENGER, InntektYtelseType.SYKEPENGER_FISKER_HYRE, InntektYtelseType.FORELDREPENGER,
+                InntektYtelseType.SVANGERSKAPSPENGER, InntektYtelseType.PLEIEPENGER, InntektYtelseType.OMSORGSPENGER,
+                InntektYtelseType.OPPLÆRINGSPENGER).contains(p.inntektYtelseType());
+    }
+
+    private static boolean localDateTimeInYearMonth(LocalDate ldt, YearMonth yearMonth) {
+        return YearMonth.of(ldt.getYear(), ldt.getMonth()).compareTo(yearMonth) == 0;
+    }
+
+    private static String fraModellInntektstype(InntektType modellType) {
+        return switch (modellType) {
+            case LØNNSINNTEKT -> "Loennsinntekt";
+            case NÆRINGSINNTEKT -> "Naeringsinntekt";
+            case PENSJON_ELLER_TRYGD -> "PensjonEllerTrygd";
+            case YTELSE_FRA_OFFENTLIGE -> "YtelseFraOffentlige";
+        };
+    }
+
+}

--- a/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/modell/InntektModellMapper.java
+++ b/mocks/inntekt-mock/src/main/java/no/nav/vtp/inntektskomponenten/modell/InntektModellMapper.java
@@ -15,49 +15,48 @@ import no.nav.vtp.inntektskomponenten.Inntektsinformasjon;
 
 public class InntektModellMapper {
 
-    public static List<Inntektsinformasjon> makeInntektsinformasjon(InntektskomponentModell modell, YearMonth fom, YearMonth tom, String filter) {
+    public static List<Inntektsinformasjon> makeInntektsinformasjon(InntektskomponentModell modell, YearMonth fom, YearMonth tom,
+                                                                    String filter, String brukerIdent) {
 
         List<Inntektsinformasjon> respons = new ArrayList<>();
 
         YearMonth runningMonth = fom;
         while (runningMonth.isBefore(tom) || runningMonth.equals(tom)) {
-            respons.addAll(makeArbeidsInntektInformasjonForMåned(modell, runningMonth, filter));
+            respons.addAll(inntektListeFraModell(modell.getInntektsperioderSplittMånedlig(), runningMonth, filter, brukerIdent));
             runningMonth = runningMonth.plusMonths(1);
         }
 
         return respons;
     }
 
-    private static List<Inntektsinformasjon> makeArbeidsInntektInformasjonForMåned(InntektskomponentModell modell, YearMonth måned, String filter) {
-        return inntektListeFraModell(modell.getInntektsperioderSplittMånedlig(), måned, filter);
-    }
-
-    private static List<Inntektsinformasjon> inntektListeFraModell(List<Inntektsperiode> modellPeriode, YearMonth måned, String filter) {
+    private static List<Inntektsinformasjon> inntektListeFraModell(List<Inntektsperiode> modellPeriode, YearMonth måned,
+                                                                   String filter, String brukerIdent) {
         return modellPeriode.stream()
                 .filter(t -> localDateTimeInYearMonth(t.tom(), måned))
                 .filter(t -> taMedFraInntektsfilter(t, filter))
-                .map(temp -> inntektFraModell(temp, måned))
+                .map(temp -> inntektFraModell(temp, måned, brukerIdent))
                 .toList();
     }
 
-    private static Inntektsinformasjon inntektFraModell(Inntektsperiode ip, YearMonth måned) {
-        var underenhet = ip.orgnr() != null  && !ip.orgnr().isEmpty() ? ip.orgnr() : null;
-        var personag = ip.orgnr() == null  || ip.orgnr().isEmpty() ? ip.arbeidsgiver().getAktørIdent() : null;
+    private static Inntektsinformasjon inntektFraModell(Inntektsperiode ip, YearMonth måned, String brukerIdent) {
+        var underenhet = ip.orgnr() != null  && !ip.orgnr().isEmpty() ? ip.orgnr() : ip.arbeidsgiver().getAktørIdent();
         var inntekt =  new Inntektsinformasjon.Inntekt(fraModellInntektstype(ip.inntektType()), new BigDecimal(ip.beløp()),
                 ip.beskrivelse(), ip.skatteOgAvgiftsregel(), ip.fom(), ip.tom(), null);
-        return new Inntektsinformasjon(måned, null, underenhet, personag, List.of(inntekt));
+        return new Inntektsinformasjon(måned, null, underenhet, brukerIdent, List.of(inntekt));
     }
 
     private static boolean taMedFraInntektsfilter(Inntektsperiode p, String filter) {
-        var filter82830 = filter.startsWith("8");
-        if (!filter82830 || p.inntektYtelseType() == null || InntektYtelseType.InntektType.LØNNSINNTEKT.equals(p.inntektYtelseType().getInntektType())) {
+        // Opptjeningsfilter har med alt. Lønn skal alltid med
+        if (!filter.startsWith("8") || p.inntektYtelseType() == null || InntektYtelseType.InntektType.LØNNSINNTEKT.equals(p.inntektYtelseType().getInntektType())) {
             return true;
         }
+        // Beregningsfilter har ikke med ytelser
         if (filter.startsWith("8-28") ||
                 InntektYtelseType.InntektType.PENSJON_ELLER_TRYGD.equals(p.inntektYtelseType().getInntektType()) ||
                 InntektYtelseType.InntektType.NÆRINGSINNTEKT.equals(p.inntektYtelseType().getInntektType())) {
             return false;
         }
+        // Sammenligningsfilter har med enkelte ytelser (ikke DAG, AAP)
         return Set.of(InntektYtelseType.SYKEPENGER, InntektYtelseType.SYKEPENGER_FISKER_HYRE, InntektYtelseType.FORELDREPENGER,
                 InntektYtelseType.SVANGERSKAPSPENGER, InntektYtelseType.PLEIEPENGER, InntektYtelseType.OMSORGSPENGER,
                 InntektYtelseType.OPPLÆRINGSPENGER).contains(p.inntektYtelseType());

--- a/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/ArbeidsavklaringspengerResponse.java
+++ b/mocks/kelvin-mock/src/main/java/no/nav/tjeneste/virksomhet/kelvin/ArbeidsavklaringspengerResponse.java
@@ -6,8 +6,9 @@ import java.util.List;
 
 public record ArbeidsavklaringspengerResponse(List<AAPVedtak> vedtak) {
 
-    public record AAPVedtak(Integer barnMedStonad, Integer beregningsgrunnlag, Integer dagsats,
-                            Kildesystem kildesystem, AAPPeriode periode, String saksnummer,
+    public record AAPVedtak(Integer barnMedStonad, Integer barnetillegg, Integer beregningsgrunnlag,
+                            Integer dagsats, Integer dagsatsEtterUføreReduksjon,
+                            Kildesystem kildesystem, AAPPeriode periode, String saksnummer, String status,
                             String vedtakId, LocalDate vedtaksdato, List<AAPUtbetaling> utbetaling) { }
 
 

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfigJersey.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfigJersey.java
@@ -101,6 +101,7 @@ import no.nav.vtp.DummyRestTjeneste;
 import no.nav.vtp.DummyRestTjenesteBoolean;
 import no.nav.vtp.DummyRestTjenesteFile;
 import no.nav.vtp.hentinntektlistebolk.HentInntektlisteBolkREST;
+import no.nav.vtp.inntektskomponenten.InntektskomponentV2REST;
 
 @ApplicationPath(ApplicationConfigJersey.API_URI)
 public class ApplicationConfigJersey extends ResourceConfig {
@@ -144,6 +145,7 @@ public class ApplicationConfigJersey extends ResourceConfig {
         classes.add(SafMock.class);
         classes.add(PdlLeesahRestTjeneste.class);
         classes.add(HentInntektlisteBolkREST.class);
+        classes.add(InntektskomponentV2REST.class);
         classes.add(DummyRestTjeneste.class);
         classes.add(DummyRestTjenesteFile.class);
         classes.add(DummyRestTjenesteBoolean.class);


### PR DESCRIPTION
Pilotert i fp-risk i prod. Alt funker helt OK.
Fordel: Slipper med 1 kall når man trenger flere filtere - og det er bare ett kall videre selv med 3 filtre.

De har en artifakt, men den er internal så bygger lokalt men får mye 401 ved bygging i github. 
Følger opp saken - men modellen er enkel så tar bare med aktuelle elementer her

@qtips og @espenjv - Inntk V2 har ikke frilansoppdrag før 2020, slik som V1. Frisinn brukte disse. Bør se på å la k9-abakus  beholde gamle frilansting fra V1 ved registeroppdatering. Evt skru av frisinn.