### PR TITLE
Legg til tilleggsopplysninger felt i JournalpostModell for k9-punsj kompatibilitet

### DIFF
--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
@@ -36,6 +36,7 @@ public class JournalpostModell {
     private Journalposttyper journalposttype;
     private JournalpostBruker bruker;
     private String behandlingTema;
+    private List<Object> tilleggsopplysninger = new ArrayList<>();
 
     public JournalpostModell() {
     }
@@ -205,17 +206,25 @@ public class JournalpostModell {
         this.behandlingTema = behandlingTema;
     }
 
+    public List<Object> getTilleggsopplysninger() {
+        return tilleggsopplysninger;
+    }
+
+    public void setTilleggsopplysninger(List<Object> tilleggsopplysninger) {
+        this.tilleggsopplysninger = tilleggsopplysninger;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JournalpostModell that = (JournalpostModell) o;
-        return Objects.equals(journalpostId, that.journalpostId) && Objects.equals(eksternReferanseId, that.eksternReferanseId) && Objects.equals(tittel, that.tittel) && Objects.equals(dokumentModellList, that.dokumentModellList) && Objects.equals(avsenderMottaker, that.avsenderMottaker) && Objects.equals(sakId, that.sakId) && Objects.equals(fagsystemId, that.fagsystemId) && Objects.equals(journalStatus, that.journalStatus) && Objects.equals(kommunikasjonsretning, that.kommunikasjonsretning) && Objects.equals(mottattDato, that.mottattDato) && Objects.equals(mottakskanal, that.mottakskanal) && Objects.equals(arkivtema, that.arkivtema) && Objects.equals(journaltilstand, that.journaltilstand) && Objects.equals(journalposttype, that.journalposttype) && Objects.equals(bruker, that.bruker);
+        return Objects.equals(journalpostId, that.journalpostId) && Objects.equals(eksternReferanseId, that.eksternReferanseId) && Objects.equals(tittel, that.tittel) && Objects.equals(dokumentModellList, that.dokumentModellList) && Objects.equals(avsenderMottaker, that.avsenderMottaker) && Objects.equals(sakId, that.sakId) && Objects.equals(fagsystemId, that.fagsystemId) && Objects.equals(journalStatus, that.journalStatus) && Objects.equals(kommunikasjonsretning, that.kommunikasjonsretning) && Objects.equals(mottattDato, that.mottattDato) && Objects.equals(mottakskanal, that.mottakskanal) && Objects.equals(arkivtema, that.arkivtema) && Objects.equals(journaltilstand, that.journaltilstand) && Objects.equals(journalposttype, that.journalposttype) && Objects.equals(bruker, that.bruker) && Objects.equals(tilleggsopplysninger, that.tilleggsopplysninger);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(journalpostId, eksternReferanseId, tittel, dokumentModellList, avsenderMottaker, sakId, fagsystemId, journalStatus, kommunikasjonsretning, mottattDato, mottakskanal, arkivtema, journaltilstand, journalposttype, bruker);
+        return Objects.hash(journalpostId, eksternReferanseId, tittel, dokumentModellList, avsenderMottaker, sakId, fagsystemId, journalStatus, kommunikasjonsretning, mottattDato, mottakskanal, arkivtema, journaltilstand, journalposttype, bruker, tilleggsopplysninger);
     }
 
     @Override
@@ -233,6 +242,7 @@ public class JournalpostModell {
                 ", arkivtema=" + arkivtema +
                 ", journaltilstand='" + journaltilstand + '\'' +
                 ", journalposttype=" + journalposttype +
+                ", tilleggsopplysninger=" + tilleggsopplysninger +
                 '}';
     }
 

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/JournalpostModell.java
@@ -36,7 +36,7 @@ public class JournalpostModell {
     private Journalposttyper journalposttype;
     private JournalpostBruker bruker;
     private String behandlingTema;
-    private List<Object> tilleggsopplysninger = new ArrayList<>();
+    private List<Tilleggsopplysning> tilleggsopplysninger = new ArrayList<>();
 
     public JournalpostModell() {
     }
@@ -206,11 +206,11 @@ public class JournalpostModell {
         this.behandlingTema = behandlingTema;
     }
 
-    public List<Object> getTilleggsopplysninger() {
+    public List<Tilleggsopplysning> getTilleggsopplysninger() {
         return tilleggsopplysninger;
     }
 
-    public void setTilleggsopplysninger(List<Object> tilleggsopplysninger) {
+    public void setTilleggsopplysninger(List<Tilleggsopplysning> tilleggsopplysninger) {
         this.tilleggsopplysninger = tilleggsopplysninger;
     }
 

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/Tilleggsopplysning.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/Tilleggsopplysning.java
@@ -1,0 +1,3 @@
+package no.nav.foreldrepenger.vtp.testmodell.dokument.modell;
+
+public record Tilleggsopplysning(String nokkel, String verdi) {}

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/JournalRepoTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/JournalRepoTest.java
@@ -87,15 +87,29 @@ public class JournalRepoTest {
     public void testTilleggsopplysningerField() {
         JournalpostModell journalpostModell = new JournalpostModell();
 
+        // Sjekker at felt er initialisert som tom liste
         assertThat(journalpostModell.getTilleggsopplysninger()).isNotNull();
         assertThat(journalpostModell.getTilleggsopplysninger()).isEmpty();
 
+        // Tester setter
         List<Object> testData = List.of("test1", "test2");
         journalpostModell.setTilleggsopplysninger(testData);
         assertThat(journalpostModell.getTilleggsopplysninger()).isEqualTo(testData);
 
+        // Tester equals funksjonalitet
         JournalpostModell journalpostModell2 = new JournalpostModell();
         journalpostModell2.setTilleggsopplysninger(testData);
         assertThat(journalpostModell.getTilleggsopplysninger()).isEqualTo(journalpostModell2.getTilleggsopplysninger());
+
+        // Tester hashCode (dekker hashCode linje)
+        assertThat(journalpostModell.hashCode()).isEqualTo(journalpostModell2.hashCode());
+
+        journalpostModell.setAvsenderFnr("12345678901");
+        journalpostModell2.setAvsenderFnr("12345678901");
+
+        // Tester toString (dekker toString linje)
+        String toString = journalpostModell.toString();
+        assertThat(toString).contains("tilleggsopplysninger");
+        assertThat(toString).contains("test1");
     }
 }

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/JournalRepoTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/JournalRepoTest.java
@@ -82,4 +82,20 @@ public class JournalRepoTest {
         assertThat(resultatModell.get().getJournalpostId()).isEqualTo(journalpostId);
 
     }
+
+    @Test
+    public void testTilleggsopplysningerField() {
+        JournalpostModell journalpostModell = new JournalpostModell();
+
+        assertThat(journalpostModell.getTilleggsopplysninger()).isNotNull();
+        assertThat(journalpostModell.getTilleggsopplysninger()).isEmpty();
+
+        List<Object> testData = List.of("test1", "test2");
+        journalpostModell.setTilleggsopplysninger(testData);
+        assertThat(journalpostModell.getTilleggsopplysninger()).isEqualTo(testData);
+
+        JournalpostModell journalpostModell2 = new JournalpostModell();
+        journalpostModell2.setTilleggsopplysninger(testData);
+        assertThat(journalpostModell.getTilleggsopplysninger()).isEqualTo(journalpostModell2.getTilleggsopplysninger());
+    }
 }

--- a/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/JournalRepoTest.java
+++ b/model/src/test/java/no/nav/foreldrepenger/vtp/testmodell/JournalRepoTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.DokumentModell;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.JournalpostModell;
+import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.Tilleggsopplysning;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.DokumentTilknyttetJournalpost;
 import no.nav.foreldrepenger.vtp.testmodell.dokument.modell.koder.DokumenttypeId;
 import no.nav.foreldrepenger.vtp.testmodell.repo.JournalRepository;
@@ -92,7 +93,12 @@ public class JournalRepoTest {
         assertThat(journalpostModell.getTilleggsopplysninger()).isEmpty();
 
         // Tester setter
-        List<Object> testData = List.of("test1", "test2");
+        List<Tilleggsopplysning> testData = List.of(
+                new Tilleggsopplysning("k9.kilde", "SKANNING"),
+                new Tilleggsopplysning("k9.type", "SØKNAD")
+
+        );
+
         journalpostModell.setTilleggsopplysninger(testData);
         assertThat(journalpostModell.getTilleggsopplysninger()).isEqualTo(testData);
 
@@ -110,6 +116,6 @@ public class JournalRepoTest {
         // Tester toString (dekker toString linje)
         String toString = journalpostModell.toString();
         assertThat(toString).contains("tilleggsopplysninger");
-        assertThat(toString).contains("test1");
+        assertThat(toString).contains("k9.kilde");
     }
 }


### PR DESCRIPTION
## Behov / Bakgrunn
JournalpostModell mangler `tilleggsopplysninger` felt som k9-punsj krever for journalposter.

**Feil i K9-punsj:** `JSON decoding error: Instantiation of [simple type, class no.nav.k9punsj.integrasjoner.dokarkiv.SafDtos$Journalpost] value failed for JSON property tilleggsopplysninger due to missing (therefore NULL) value for creator parameter tilleggsopplysninger which is a non-nullable type`

## Løsning
Legg til `tilleggsopplysninger` felt i `JournalpostModell` med tom array som default verdi.