### PR TITLE
Fikser tilOpprettJouralpostResponse() så den ikke alltid ferdigstiller

### DIFF
--- a/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMock.java
+++ b/mocks/journalpost-mock/src/main/java/no/nav/dokarkiv/JournalpostMock.java
@@ -1,7 +1,6 @@
 package no.nav.dokarkiv;
 
 import java.util.Collections;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.PATCH;
@@ -70,7 +69,7 @@ public class JournalpostMock {
             journalforingHendelseSender.leggTilJournalføringHendelsePåKafka(journalpostModell);
         }
 
-        OpprettJournalpostResponse response = tilOpprettJouralpostResponse(journalpostModell);
+        OpprettJournalpostResponse response = tilOpprettJouralpostResponse(journalpostModell, forsoekFerdigstill);
         return Response.accepted().entity(response).build();
     }
 
@@ -124,7 +123,7 @@ public class JournalpostMock {
     }
 
 
-    private OpprettJournalpostResponse tilOpprettJouralpostResponse(JournalpostModell journalpostModell) {
+    private OpprettJournalpostResponse tilOpprettJouralpostResponse(JournalpostModell journalpostModell, Boolean forsoekFerdigstill) {
         var dokumentInfos = journalpostModell.getDokumentModellList().stream()
                 .map(it -> {
                     DokumentInfo dokinfo = new DokumentInfo();
@@ -137,7 +136,7 @@ public class JournalpostMock {
         var response = new OpprettJournalpostResponse();
         response.setDokumenter(dokumentInfos);
         response.setJournalpostId(journalpostModell.getJournalpostId());
-        response.setJournalpostferdigstilt(Boolean.TRUE);
+        response.setJournalpostferdigstilt(forsoekFerdigstill != null && forsoekFerdigstill);
         return response;
     }
 }

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BehandlingsTema.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BehandlingsTema.java
@@ -25,7 +25,7 @@ public enum BehandlingsTema {
 
     UNGDOMSPROGRAMYTELSEN("UNGDOMSPROGRAMYTELSEN", "ab0564", "Ungdomsprogramytelsen"),
 
-    UDEFINERT("-", "-", "Ikke definert"),
+    UDEFINERT("-", null, "Ikke definert"),
     ;
 
     private final String kode;

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BehandlingsTema.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BehandlingsTema.java
@@ -23,6 +23,8 @@ public enum BehandlingsTema {
     OMS_PLEIE_BARN_NY("OMS_PLEIE_BARN_NY", "ab0320", "Pleiepenger sykt barn ny ordning"),
     OMS_PLEIE_INSTU("OMS_PLEIE_INSTU", "ab0153", "Pleiepenger ved institusjonsopphold"),
 
+    UNGDOMSPROGRAMYTELSEN("UNGDOMSPROGRAMYTELSEN", "ab0564", "Ungdomsprogramytelsen"),
+
     UDEFINERT("-", "-", "Ikke definert"),
     ;
 

--- a/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BehandlingsTema.java
+++ b/model/src/main/java/no/nav/foreldrepenger/vtp/testmodell/dokument/modell/koder/BehandlingsTema.java
@@ -23,7 +23,7 @@ public enum BehandlingsTema {
     OMS_PLEIE_BARN_NY("OMS_PLEIE_BARN_NY", "ab0320", "Pleiepenger sykt barn ny ordning"),
     OMS_PLEIE_INSTU("OMS_PLEIE_INSTU", "ab0153", "Pleiepenger ved institusjonsopphold"),
 
-    UDEFINERT("-", null, "Ikke definert"),
+    UDEFINERT("-", "-", "Ikke definert"),
     ;
 
     private final String kode;


### PR DESCRIPTION
## Bakgrunn
Ved opprettelse av journalpost returneres det alltid `forsoekFerdigstill` til true.

## Løsning
- `journalpostferdigstilt` settes nå som følge av `forsoekFerdigstill`. Dersom den er satt settes verdien, enten `true/false`.
Dersom den ikke er satt, settes det default til `false`.
- Sender journalføringshendelse dersom `kanal` er `NAV_NO` og `tittel` er lik `Inntektsmelding` eller inneholder `ungdomsprogramytelse`.
- Definerer `Behandlingstema` for `Ungdomsprogramytelsen`. Kilde: https://kodeverk.ansatt.nav.no/kodeverk/Behandlingstema/200001110 

Kilde: https://confluence.adeo.no/spaces/BOA/pages/313346837/opprettJournalpost 