### PR TITLE
Teknisk: Bruk fp-graphql framfor ikke-vedlikeholdt verktøy

### DIFF
--- a/mocks/fager-mock/pom.xml
+++ b/mocks/fager-mock/pom.xml
@@ -36,8 +36,8 @@
             <artifactId>graphql-java-extended-scalars</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.kobylynskyi</groupId>
-            <artifactId>graphql-java-codegen</artifactId>
+            <groupId>no.nav.foreldrepenger.graphql</groupId>
+            <artifactId>graphql-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -57,8 +57,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.github.kobylynskyi</groupId>
-                <artifactId>graphql-codegen-maven-plugin</artifactId>
+                <groupId>no.nav.foreldrepenger.graphql</groupId>
+                <artifactId>graphql-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <goals>
@@ -68,17 +68,7 @@
                             <graphqlSchemaPaths>${project.basedir}/src/main/resources/schemas/produsent.graphql</graphqlSchemaPaths>
                             <outputDir>${project.build.directory}/generated-sources/graphql</outputDir>
                             <packageName>no.nav.fager</packageName>
-                            <customTypesMapping>
-                                <DateTime>java.util.Date</DateTime>
-                            </customTypesMapping>
-                            <generateClient>true</generateClient>
-                            <generateApis>false</generateApis>
                             <generateBuilder>true</generateBuilder>
-                            <generateToString>true</generateToString>
-                            <generateParameterizedFieldsResolvers>false</generateParameterizedFieldsResolvers>
-                            <addGeneratedAnnotation>true</addGeneratedAnnotation>
-                            <generatedAnnotation>jakarta.annotation.Generated</generatedAnnotation>
-                            <modelValidationAnnotation>@jakarta.validation.constraints.NotNull</modelValidationAnnotation>
                             <generateJacksonTypeIdResolver>true</generateJacksonTypeIdResolver>
                         </configuration>
                     </execution>

--- a/mocks/pdl-mock/pom.xml
+++ b/mocks/pdl-mock/pom.xml
@@ -19,6 +19,10 @@
 
     <dependencies>
         <dependency>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+        </dependency>
+        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
         </dependency>
@@ -32,8 +36,8 @@
             <artifactId>graphql-java-extended-scalars</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.kobylynskyi</groupId>
-            <artifactId>graphql-java-codegen</artifactId>
+            <groupId>no.nav.foreldrepenger.graphql</groupId>
+            <artifactId>graphql-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -54,8 +58,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.github.kobylynskyi</groupId>
-                <artifactId>graphql-codegen-maven-plugin</artifactId>
+                <groupId>no.nav.foreldrepenger.graphql</groupId>
+                <artifactId>graphql-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <goals>
@@ -68,20 +72,8 @@
                             <packageName>no.nav.pdl</packageName>
                             <customTypesMapping>
                                 <DateTime>java.util.Date</DateTime>
-                                <!-- <Price.amount>java.math.BigDecimal</Price.amount> -->
                             </customTypesMapping>
-                            <customAnnotationsMapping>
-                                <EpochMillis>
-                                    <annotation>com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.example.json.EpochMillisScalarDeserializer.class)</annotation>
-                                </EpochMillis>
-                            </customAnnotationsMapping>
-                            <generateClient>true</generateClient>
-                            <!--<generateClient>true</generateClient>
-                            <generateApis>false</generateApis>
-                            <generateBuilder>false</generateBuilder>
-                            <generateToString>true</generateToString>-->
-                            <generateParameterizedFieldsResolvers>false</generateParameterizedFieldsResolvers>
-                            <modelValidationAnnotation>@jakarta.validation.constraints.NotNull</modelValidationAnnotation>
+                            <generateBuilder>true</generateBuilder>
                         </configuration>
                     </execution>
                 </executions>

--- a/mocks/pdl-mock/src/test/java/no/nav/pdl/PdlTestBase.java
+++ b/mocks/pdl-mock/src/test/java/no/nav/pdl/PdlTestBase.java
@@ -5,8 +5,8 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLResult;
 
+import no.nav.foreldrepenger.graphql.GraphQLResult;
 import no.nav.foreldrepenger.util.JacksonObjectMapperTestscenario;
 
 public abstract class PdlTestBase {

--- a/mocks/pom.xml
+++ b/mocks/pom.xml
@@ -41,7 +41,7 @@
     </modules>
 
     <properties>
-        <graphql-java-codegen.version>5.10.0</graphql-java-codegen.version>
+        <fp-graphql.version>1.0.0</fp-graphql.version>
     </properties>
 
     <dependencyManagement>
@@ -58,9 +58,9 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>io.github.kobylynskyi</groupId>
-                <artifactId>graphql-java-codegen</artifactId>
-                <version>${graphql-java-codegen.version}</version>
+                <groupId>no.nav.foreldrepenger.graphql</groupId>
+                <artifactId>graphql-runtime</artifactId>
+                <version>${fp-graphql.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -95,12 +95,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>io.github.kobylynskyi</groupId>
-                    <artifactId>graphql-codegen-maven-plugin</artifactId>
-                    <version>${graphql-java-codegen.version}</version>
+                    <groupId>no.nav.foreldrepenger.graphql</groupId>
+                    <artifactId>graphql-maven-plugin</artifactId>
+                    <version>${fp-graphql.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
-
     </build>
 </project>

--- a/mocks/saf-mock/pom.xml
+++ b/mocks/saf-mock/pom.xml
@@ -19,6 +19,14 @@
 
     <dependencies>
         <dependency>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.graphql</groupId>
+            <artifactId>graphql-runtime</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
         </dependency>
@@ -36,8 +44,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>io.github.kobylynskyi</groupId>
-                <artifactId>graphql-codegen-maven-plugin</artifactId>
+                <groupId>no.nav.foreldrepenger.graphql</groupId>
+                <artifactId>graphql-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>saf</id>
@@ -46,20 +54,13 @@
                         </goals>
                         <configuration>
                             <!-- source repo:saf:app/src/main/resources/schemas/saf.graphqls -->
-                            <graphqlSchemaPaths>
-                                <graphqlSchemaPath>${project.basedir}/src/main/resources/schemas/saf.graphqls</graphqlSchemaPath>
-                            </graphqlSchemaPaths>
+                            <graphqlSchemaPaths>${project.basedir}/src/main/resources/schemas/saf.graphqls</graphqlSchemaPaths>
                             <outputDir>${project.build.directory}/generated-sources/graphql</outputDir>
                             <packageName>no.nav.saf</packageName>
                             <customTypesMapping>
                                 <DateTime>java.util.Date</DateTime>
                             </customTypesMapping>
-                            <customAnnotationsMapping>
-                                <EpochMillis>
-                                    <annotation>com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.example.json.EpochMillisScalarDeserializer.class)</annotation>
-                                </EpochMillis>
-                            </customAnnotationsMapping>
-                            <modelValidationAnnotation>@jakarta.validation.constraints.NotNull</modelValidationAnnotation>
+                            <generateBuilder>true</generateBuilder>
                         </configuration>
                     </execution>
                     <execution>
@@ -77,12 +78,7 @@
                             <customTypesMapping>
                                 <DateTime>java.util.Date</DateTime>
                             </customTypesMapping>
-                            <customAnnotationsMapping>
-                                <EpochMillis>
-                                    <annotation>com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.example.json.EpochMillisScalarDeserializer.class)</annotation>
-                                </EpochMillis>
-                            </customAnnotationsMapping>
-                            <modelValidationAnnotation>@jakarta.validation.constraints.NotNull</modelValidationAnnotation>
+                            <generateBuilder>true</generateBuilder>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
             <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id> <!-- OBS: Brukes også av fp-gha-workflows for action/setup-java -->
+            <url>https://maven.pkg.github.com/navikt/fp-graphql</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
Den forrige generatoren har ikke vært rørt på 2 år og utvikler bodde et utsatt område. 
Vi bruker nå repo fp-graphql - 10-15 runtimeklasser og en maven-plugin
Alt er testet lokalt. Jackson3 kommer ganske snart.
Må legge til pluginRepositories i sin lokale settings.xml for å bygge vtp etter dette.