### PR TITLE
fix: reparer release drafter som viste ingen endringer

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,28 +2,9 @@ name-template: $NEXT_PATCH_VERSION
 tag-template: $NEXT_PATCH_VERSION
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 categories:
-  - title: '🚀 Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
-  - title: '⚠️ Breaking Changes'
-    labels:
-      - 'breaking'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-  - title: '🧰 Maintenance'
-    labels:
-      - 'chore'
   - title: '⬆️ Dependency upgrades'
     labels:
-      - 'bump'
       - 'dependencies'
-include-labels:
-  - 'kontrakt'
-  - 'mocks'
 template: |
   ## What's Changed
   $CHANGES


### PR DESCRIPTION
Rotårsak: include-labels: ['kontrakt'] filtrerte ut alle PRs fordi labeler-workflowen som satte denne labelen ikke lenger finnes.

- Fjerner include-labels-filter
- Fjerner ubrukte kategorier (feature, bug, chore, breaking)
- Beholder kun 'dependencies'-kategori (settes av Dependabot)