### PR TITLE
Chore: Spisser release til kun kontrakter

### DIFF
--- a/.github/workflows/build-kontrakt.yml
+++ b/.github/workflows/build-kontrakt.yml
@@ -1,0 +1,33 @@
+name: Bygg kontrakt
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - 'kontrakter/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Kontrakt
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      pull-requests: read
+    uses: navikt/fp-gha-workflows/.github/workflows/build-feature.yml@main  # ratchet:exclude
+    with:
+      java-version: '25'
+      working-directory: ./kontrakter # Sett working directory til kontrakt-mappen
+    secrets: inherit
+
+  release-drafter:
+    name: Update
+    if: github.ref_name == 'master'
+    needs: build
+    permissions:
+      contents: write
+      pull-requests: read
+    uses: navikt/fp-gha-workflows/.github/workflows/release-drafter.yml@main  # ratchet:exclude
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
       - 'CODEOWNERS'
       - 'docs/**'
       - '.github/*.yml'
+      - 'kontrakter/**'
 
 jobs:
   build-app:
@@ -82,13 +83,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  release-drafter:
-    name: Update
-    permissions:
-      contents: write
-      pull-requests: read
-    if: github.ref_name == 'master'
-    needs: build-app
-    uses: navikt/fp-gha-workflows/.github/workflows/release-drafter.yml@main # ratchet:exclude
-    secrets: inherit

--- a/.github/workflows/release-kontrakt.yml
+++ b/.github/workflows/release-kontrakt.yml
@@ -5,12 +5,12 @@ on:
 
 jobs:
   release:
-    name: Feature
+    name: Kontrakt
     permissions:
       contents: read
       packages: write
     uses: navikt/fp-gha-workflows/.github/workflows/release-feature.yml@main # ratchet:exclude
     with:
       release-version: ${{ github.event.release.tag_name }}
-      mvn-projects: '-am -pl kontrakter'
+      working-directory: ./kontrakter # Sett working directory til kontrakter-mappen
     secrets: inherit

--- a/kontrakter/pom.xml
+++ b/kontrakter/pom.xml
@@ -5,12 +5,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>no.nav.foreldrepenger.vtp</groupId>
-        <artifactId>vtp</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>no.nav.foreldrepenger.felles</groupId>
+        <artifactId>fp-parent-lib</artifactId>
+        <version>5.3.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
+    <groupId>no.nav.foreldrepenger.vtp</groupId>
     <artifactId>kontrakter</artifactId>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>VTP ::Kontrakter</name>
 
@@ -18,6 +21,7 @@
         <dependency>
             <groupId>com.neovisionaries</groupId>
             <artifactId>nv-i18n</artifactId>
+            <version>1.29</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -33,5 +37,28 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/navikt/vtp/</url>
+        </repository>
+    </repositories>
+
+    <scm>
+        <connection>scm:git:https://github.com/navikt/vtp.git</connection>
+        <developerConnection>scm:git:https://github.com/navikt/vtp.git</developerConnection>
+        <url>https://github.com/navikt/vtp</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>Github navikt Maven Packages</name>
+            <url>https://maven.pkg.github.com/navikt/vtp</url>
+        </repository>
+    </distributionManagement>
 
 </project>

--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/FødselsnummerGenerator.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/FødselsnummerGenerator.java
@@ -6,15 +6,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.vtp.kontrakter.person.Kjønn;
 
 public class FødselsnummerGenerator {
     private static final Set<String> BRUKTE_FØDSELSNUMMER = new ConcurrentSkipListSet<>();
 
-    private static final Logger LOG = LoggerFactory.getLogger(FødselsnummerGenerator.class);
     private static final Integer NAV_SYNTETISK_IDENT_OFFSET_MND = 40;
     private static final int MAX_GENERATE_ATTEMPTS = 1000;
 
@@ -67,7 +63,6 @@ public class FødselsnummerGenerator {
             } else if (betweenInclusive(fullYear, 2000, 2039)) {
                 validRange = betweenInclusive(birthNumber, 500, 999);
             } else {
-                LOG.info("Kunne ikke identifisere fødselsnummerserie");
                 validRange = true;
             }
             if (!validRange) {
@@ -122,7 +117,6 @@ public class FødselsnummerGenerator {
             for (int attempt = 0; attempt < MAX_GENERATE_ATTEMPTS; attempt++) {
                 var nyttFnr = new FødselsnummerGenerator(this).generate();
                 if (!BRUKTE_FØDSELSNUMMER.add(nyttFnr)) {
-                    LOG.warn("FØDSELSNUMMER FINNES, GENERER NYTT (forsøk {})", attempt + 1);
                     continue;
                 }
                 return nyttFnr;

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
     <name>VTP :: Root</name>
 
     <modules>
-        <module>kontrakter</module>
         <module>mocks</module>
         <module>server</module>
         <module>util</module>
@@ -29,6 +28,7 @@
         <sonar.projectKey>navikt_vtp</sonar.projectKey>
 
         <!--    Interne avhengigheter    -->
+        <vtp-kontrakter.version>2.2.0</vtp-kontrakter.version>
         <fp-kontrakter.version>9.4.36</fp-kontrakter.version>
 
         <!--    Eksterne avhengigheter    -->
@@ -61,7 +61,7 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.vtp</groupId>
                 <artifactId>kontrakter</artifactId>
-                <version>${project.version}</version>
+                <version>${vtp-kontrakter.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.nav.foreldrepenger.vtp</groupId>


### PR DESCRIPTION
Samme mønster som i andre repos
- To byggejobber - en vanlig og en i kontrakter
- Release-draft kun for kontraktsendringer
- Release kun av kontrakter (som nå)
- VTP importerer releaset versjon av vtp-kontrakter - (kan sette snapshot lokalt)

Ved endring av kontrakter så må den bygges og releases, så tas inn i VTP.