### PR TITLE
Legg til Maskinporten token-endepunkt og Dialogporten mock

### DIFF
--- a/mocks/altinn-proxy-mock/src/main/java/no/nav/altinn/AltinnPlatformMock.java
+++ b/mocks/altinn-proxy-mock/src/main/java/no/nav/altinn/AltinnPlatformMock.java
@@ -1,8 +1,11 @@
 package no.nav.altinn;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -14,6 +17,7 @@ import org.slf4j.LoggerFactory;
  * Mock for Altinn 3 platform tjenester:
  * - Token exchange (Maskinporten → Altinn token)
  * - PDP authorization (sjekk om system har tilgang til organisasjon)
+ * - Dialogporten (opprette og oppdatere dialoger)
  */
 @Path("/dummy/altinn-tre")
 public class AltinnPlatformMock {
@@ -34,5 +38,24 @@ public class AltinnPlatformMock {
         LOG.info("Altinn mock: PDP authorize kall mottatt");
         var permitResponse = "{\"response\":[{\"decision\":\"Permit\"}]}";
         return Response.ok(permitResponse).build();
+    }
+
+    @POST
+    @Path("/dialogporten/api/v1/serviceowner/dialogs")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response opprettDialog(String body) {
+        LOG.info("Altinn mock: Dialogporten opprett dialog kall mottatt");
+        var dialogId = java.util.UUID.randomUUID().toString();
+        return Response.ok("\"" + dialogId + "\"").build();
+    }
+
+    @PATCH
+    @Path("/dialogporten/api/v1/serviceowner/dialogs/{dialogId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response oppdaterDialog(@PathParam("dialogId") String dialogId, String body) {
+        LOG.info("Altinn mock: Dialogporten patch dialog kall mottatt for dialog {}", dialogId);
+        return Response.ok().build();
     }
 }

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfigJersey.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/ApplicationConfigJersey.java
@@ -7,6 +7,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import no.nav.foreldrepenger.vtp.server.auth.rest.maskinporten.MaskinportenRestTjeneste;
+
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -142,6 +144,7 @@ public class ApplicationConfigJersey extends ResourceConfig {
         classes.add(MicrosoftGraphApiMock.class);
         classes.add(TokenxRestTjeneste.class);
         classes.add(TexasRestTjeneste.class);
+        classes.add(MaskinportenRestTjeneste.class);
 
         classes.add(IsAliveImpl.class);
         classes.add(IsReadyImpl.class);

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/maskinporten/MaskinportenRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/maskinporten/MaskinportenRestTjeneste.java
@@ -1,0 +1,33 @@
+package no.nav.foreldrepenger.vtp.server.auth.rest.maskinporten;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import no.nav.foreldrepenger.vtp.server.auth.rest.Issuers;
+import no.nav.foreldrepenger.vtp.server.auth.rest.Oauth2AccessTokenResponse;
+
+@Path(MaskinportenRestTjeneste.TJENESTE_PATH)
+public class MaskinportenRestTjeneste {
+    private static final Logger LOG = LoggerFactory.getLogger(MaskinportenRestTjeneste.class);
+
+    protected static final String TJENESTE_PATH = "/maskinporten"; //NOSONAR
+
+    @POST
+    @Path("/token")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response token(@FormParam("grant_type") String grantType,
+                          @FormParam("assertion") String assertion) {
+        LOG.info("Maskinporten mock: Mottar token-forespørsel med grant_type={}", grantType);
+        String token = MaskinportenOidcTokenGenerator.maskinportenToken(
+                "digdir:dialogporten.serviceprovider", Issuers.MASKINPORTEN.getIssuer(), null, null);
+        return Response.ok(new Oauth2AccessTokenResponse(null, null, token, 600, "Bearer")).build();
+    }
+}


### PR DESCRIPTION
Legger til:

1. **Maskinporten token-endepunkt** (`/rest/maskinporten/token`) som håndterer `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` fra MaskinportenTokenKlient i fp-felles. Returnerer et gyldig maskinporten-token.

2. **Dialogporten mock** i AltinnPlatformMock:
   - POST `/dialogporten/api/v1/serviceowner/dialogs` — returnerer en UUID
   - PATCH `/dialogporten/api/v1/serviceowner/dialogs/{dialogId}` — returnerer 200 OK

3. Registrerer MaskinportenRestTjeneste i ApplicationConfigJersey.

Brukes av fp-inntektsmelding sin Dialogporten-integrasjon i lokal og CI.