### PR TITLE
Chore: kontrakt-dtos for ansatte og grupper

### DIFF
--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/organisasjon/NavAnsattDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/organisasjon/NavAnsattDto.java
@@ -1,0 +1,7 @@
+package no.nav.foreldrepenger.vtp.kontrakter.organisasjon;
+
+import java.util.List;
+import java.util.UUID;
+
+public record NavAnsattDto(String ident, UUID oid, String fornavn, String etternavn, String enhetId, List<String> grupper) {
+}

--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/organisasjon/NavGruppeDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/organisasjon/NavGruppeDto.java
@@ -1,0 +1,6 @@
+package no.nav.foreldrepenger.vtp.kontrakter.organisasjon;
+
+import java.util.UUID;
+
+public record NavGruppeDto(UUID oid, String navn) {
+}


### PR DESCRIPTION
Tar med disse som minimale Dtos i kontrakter i fall man vil lage rest-endepunkt for å legge til.
Har klar kode som leser inn fra env: VTP_GRUPPER og VTP_ANSATTE