### PR TITLE
TFP-7047 flytte ansatte og grupper til environment - fase1 enable

### DIFF
--- a/domene/src/main/java/no/nav/vtp/ansatt/AnsatteIndeks.java
+++ b/domene/src/main/java/no/nav/vtp/ansatt/AnsatteIndeks.java
@@ -6,58 +6,68 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavAnsattDto;
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavGruppeDto;
+
 public class AnsatteIndeks {
 
     // Konstanter for gjentakende grupper
-    private static final NavAnsatt.NavGroup FPSAK_SAKSBEHANDLER =
-        new NavAnsatt.NavGroup(UUID.fromString("eb211c0d-9ca6-467f-8863-9def2cc06fd3"), "0000-GA-fpsak-saksbehandler");
-    private static final NavAnsatt.NavGroup K9_SAKSBEHANDLER =
-        new NavAnsatt.NavGroup(UUID.fromString("5081d7b2-00df-442b-acb5-48eeaa114e96"), "0000-GA-k9-saksbehandler");
-    private static final NavAnsatt.NavGroup AKTIVITETSPENGER_SAKSBEHANDLER_DEL2 =
-        new NavAnsatt.NavGroup(UUID.fromString("4b3f571a-44c7-4d2b-9811-c6a1ea2cc9f4"), "0000-CA-aktivitetspenger-saksbehandler-del2");
-    private static final NavAnsatt.NavGroup INNTK_8_30 =
-        new NavAnsatt.NavGroup(UUID.fromString("99cff4e7-160a-42ba-899a-1cefd605d0e5"), "0000-GA-INNTK_8-30");
-    private static final NavAnsatt.NavGroup INNTK_8_28 =
-        new NavAnsatt.NavGroup(UUID.fromString("f9ae8c76-3230-4ae0-ba5e-b39922ae86a4"), "0000-GA-INNTK_8-28");
-    private static final NavAnsatt.NavGroup INNTK_FORELDRE =
-        new NavAnsatt.NavGroup(UUID.fromString("9698f8bb-96fb-470a-b65d-0b5541a61e9d"), "0000-GA-INNTK_FORELDRE");
-    private static final NavAnsatt.NavGroup INNTK_PENSJONSGIVENDE =
-        new NavAnsatt.NavGroup(UUID.fromString("8873e633-ac29-4463-9913-184bea045dad"), "0000-GA-INNTK_PENSJONSGIVENDE");
-    private static final NavAnsatt.NavGroup INNTK =
-        new NavAnsatt.NavGroup(UUID.fromString("39f2f9c8-1631-438a-a82e-8bed14adb672"), "0000-GA-INNTK");
-    private static final NavAnsatt.NavGroup FPSAK_BESLUTTER =
-        new NavAnsatt.NavGroup(UUID.fromString("803b1fd5-27a0-46a2-b1b3-7152f44128b4"), "0000-GA-fpsak-beslutter");
-    private static final NavAnsatt.NavGroup K9_BESLUTTER =
-        new NavAnsatt.NavGroup(UUID.fromString("ff2ab4cd-9ea4-4c51-b4cd-86a7999376a5"), "0000-GA-k9-beslutter");
-    private static final NavAnsatt.NavGroup AKTIVITETSPENGER_BESLUTTER_DEL2 =
-        new NavAnsatt.NavGroup(UUID.fromString("db408148-cf2b-4711-ad03-0ef93995eb35"), "0000-CA-aktivitetspenger-beslutter-del2");
-    private static final NavAnsatt.NavGroup FPSAK_MANUELT_OVERSTYRER =
-        new NavAnsatt.NavGroup(UUID.fromString("503f0cae-5bcd-484b-949c-a7e92d712858"), "0000-GA-fpsak-manuelt-overstyrer");
-    private static final NavAnsatt.NavGroup K9_OVERSTYRER =
-        new NavAnsatt.NavGroup(UUID.fromString("e5eccbb1-27bf-4a8f-861d-b54d7ccc8314"), "0000-GA-k9-overstyrer");
-    private static final NavAnsatt.NavGroup AKTIVITETSPENGER_OVERSTYRER_DEL2 =
-        new NavAnsatt.NavGroup(UUID.fromString("2d3d742f-3b00-4c7d-a261-b2084aadd702"), "0000-CA-aktivitetspenger-overstyrer-del2");
-    private static final NavAnsatt.NavGroup FPSAK_VEILEDER =
-        new NavAnsatt.NavGroup(UUID.fromString("edfe14fe-9a34-4ecb-8840-536ac2bc2818"), "0000-GA-fpsak-veileder");
-    private static final NavAnsatt.NavGroup K9_VEILEDER =
-        new NavAnsatt.NavGroup(UUID.fromString("79630737-b41d-41eb-93fb-30907e1afed7"), "0000-GA-k9-veileder");
-    private static final NavAnsatt.NavGroup AKTIVITETSPENGER_VEILEDER =
-        new NavAnsatt.NavGroup(UUID.fromString("6add4432-bfd1-4952-a8b4-28e746e9592c"), "0000-CA-aktivitetspenger-veileder");
-    private static final NavAnsatt.NavGroup FPSAK_OPPGAVESTYRER =
-        new NavAnsatt.NavGroup(UUID.fromString("d18989ec-5e07-494b-ad96-0c1f0c76de53"), "0000-GA-fpsak-Oppgavestyrer");
-    private static final NavAnsatt.NavGroup K9_OPPGAVESTYRER =
-        new NavAnsatt.NavGroup(UUID.fromString("d70927de-0c76-49cb-aaa7-ee67cce70aaa"), "0000-GA-k9-oppgavestyrer");
-    private static final NavAnsatt.NavGroup FPSAK_DRIFT =
-        new NavAnsatt.NavGroup(UUID.fromString("89c71f0c-ca57-4e6f-8545-990f9e24c762"), "0000-GA-fpsak-drift");
-    private static final NavAnsatt.NavGroup K9_DRIFT =
-        new NavAnsatt.NavGroup(UUID.fromString("7ac42b69-14af-479e-9e9c-b2235bea9863"), "0000-GA-k9-drift");
-    private static final NavAnsatt.NavGroup AKTIVITETSPENGER_DRIFT =
-        new NavAnsatt.NavGroup(UUID.fromString("91b518bd-04ce-4eed-8d93-6fb134e93598"), "0000-CA-aktivitetspenger-drift");
+    private static final NavGruppe FPSAK_SAKSBEHANDLER =
+        new NavGruppe(UUID.fromString("eb211c0d-9ca6-467f-8863-9def2cc06fd3"), "0000-GA-fpsak-saksbehandler");
+    private static final NavGruppe K9_SAKSBEHANDLER =
+        new NavGruppe(UUID.fromString("5081d7b2-00df-442b-acb5-48eeaa114e96"), "0000-GA-k9-saksbehandler");
+    private static final NavGruppe AKTIVITETSPENGER_SAKSBEHANDLER_DEL2 =
+        new NavGruppe(UUID.fromString("4b3f571a-44c7-4d2b-9811-c6a1ea2cc9f4"), "0000-CA-aktivitetspenger-saksbehandler-del2");
+    private static final NavGruppe INNTK_8_30 =
+        new NavGruppe(UUID.fromString("99cff4e7-160a-42ba-899a-1cefd605d0e5"), "0000-GA-INNTK_8-30");
+    private static final NavGruppe INNTK_8_28 =
+        new NavGruppe(UUID.fromString("f9ae8c76-3230-4ae0-ba5e-b39922ae86a4"), "0000-GA-INNTK_8-28");
+    private static final NavGruppe INNTK_FORELDRE =
+        new NavGruppe(UUID.fromString("9698f8bb-96fb-470a-b65d-0b5541a61e9d"), "0000-GA-INNTK_FORELDRE");
+    private static final NavGruppe INNTK_PENSJONSGIVENDE =
+        new NavGruppe(UUID.fromString("8873e633-ac29-4463-9913-184bea045dad"), "0000-GA-INNTK_PENSJONSGIVENDE");
+    private static final NavGruppe INNTK =
+        new NavGruppe(UUID.fromString("39f2f9c8-1631-438a-a82e-8bed14adb672"), "0000-GA-INNTK");
+    private static final NavGruppe FPSAK_BESLUTTER =
+        new NavGruppe(UUID.fromString("803b1fd5-27a0-46a2-b1b3-7152f44128b4"), "0000-GA-fpsak-beslutter");
+    private static final NavGruppe K9_BESLUTTER =
+        new NavGruppe(UUID.fromString("ff2ab4cd-9ea4-4c51-b4cd-86a7999376a5"), "0000-GA-k9-beslutter");
+    private static final NavGruppe AKTIVITETSPENGER_BESLUTTER_DEL2 =
+        new NavGruppe(UUID.fromString("db408148-cf2b-4711-ad03-0ef93995eb35"), "0000-CA-aktivitetspenger-beslutter-del2");
+    private static final NavGruppe FPSAK_MANUELT_OVERSTYRER =
+        new NavGruppe(UUID.fromString("503f0cae-5bcd-484b-949c-a7e92d712858"), "0000-GA-fpsak-manuelt-overstyrer");
+    private static final NavGruppe K9_OVERSTYRER =
+        new NavGruppe(UUID.fromString("e5eccbb1-27bf-4a8f-861d-b54d7ccc8314"), "0000-GA-k9-overstyrer");
+    private static final NavGruppe AKTIVITETSPENGER_OVERSTYRER_DEL2 =
+        new NavGruppe(UUID.fromString("2d3d742f-3b00-4c7d-a261-b2084aadd702"), "0000-CA-aktivitetspenger-overstyrer-del2");
+    private static final NavGruppe FPSAK_VEILEDER =
+        new NavGruppe(UUID.fromString("edfe14fe-9a34-4ecb-8840-536ac2bc2818"), "0000-GA-fpsak-veileder");
+    private static final NavGruppe K9_VEILEDER =
+        new NavGruppe(UUID.fromString("79630737-b41d-41eb-93fb-30907e1afed7"), "0000-GA-k9-veileder");
+    private static final NavGruppe AKTIVITETSPENGER_VEILEDER =
+        new NavGruppe(UUID.fromString("6add4432-bfd1-4952-a8b4-28e746e9592c"), "0000-CA-aktivitetspenger-veileder");
+    private static final NavGruppe FPSAK_OPPGAVESTYRER =
+        new NavGruppe(UUID.fromString("d18989ec-5e07-494b-ad96-0c1f0c76de53"), "0000-GA-fpsak-Oppgavestyrer");
+    private static final NavGruppe K9_OPPGAVESTYRER =
+        new NavGruppe(UUID.fromString("d70927de-0c76-49cb-aaa7-ee67cce70aaa"), "0000-GA-k9-oppgavestyrer");
+    private static final NavGruppe FPSAK_DRIFT =
+        new NavGruppe(UUID.fromString("89c71f0c-ca57-4e6f-8545-990f9e24c762"), "0000-GA-fpsak-drift");
+    private static final NavGruppe K9_DRIFT =
+        new NavGruppe(UUID.fromString("7ac42b69-14af-479e-9e9c-b2235bea9863"), "0000-GA-k9-drift");
+    private static final NavGruppe AKTIVITETSPENGER_DRIFT =
+        new NavGruppe(UUID.fromString("91b518bd-04ce-4eed-8d93-6fb134e93598"), "0000-CA-aktivitetspenger-drift");
 
-    private static final List<NavAnsatt.NavGroup> STANDARD_SAKSBEHANDLER_GRUPPER = List.of(
+    private static final List<NavGruppe> STANDARD_SAKSBEHANDLER_GRUPPER = List.of(
         FPSAK_SAKSBEHANDLER, K9_SAKSBEHANDLER, AKTIVITETSPENGER_SAKSBEHANDLER_DEL2,
         INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
     );
+
+    private static final List<NavGruppe> ALLE_GRUPPER = List.of(FPSAK_SAKSBEHANDLER, K9_SAKSBEHANDLER,
+            AKTIVITETSPENGER_SAKSBEHANDLER_DEL2, INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK,
+            FPSAK_BESLUTTER, K9_BESLUTTER, AKTIVITETSPENGER_BESLUTTER_DEL2, FPSAK_MANUELT_OVERSTYRER, K9_OVERSTYRER,
+            AKTIVITETSPENGER_OVERSTYRER_DEL2, FPSAK_VEILEDER, K9_VEILEDER, AKTIVITETSPENGER_VEILEDER, FPSAK_OPPGAVESTYRER,
+            K9_OPPGAVESTYRER, FPSAK_DRIFT, K9_DRIFT, AKTIVITETSPENGER_DRIFT);
+
 
     private static final List<NavAnsatt> ALLE_ANSATTE = List.of(
         new NavAnsatt(
@@ -68,9 +78,7 @@ public class AnsatteIndeks {
             "Saksbehandler",
             "sara.saksbehandler@example.com",
             "4833",
-            STANDARD_SAKSBEHANDLER_GRUPPER,
-            List.of()
-        ),
+            STANDARD_SAKSBEHANDLER_GRUPPER),
         new NavAnsatt(
             "S666666",
             UUID.fromString("05801408-feb8-42b2-850a-8d87adb911c7"),
@@ -81,12 +89,10 @@ public class AnsatteIndeks {
             "2103",
             List.of(
                 FPSAK_SAKSBEHANDLER, K9_SAKSBEHANDLER, AKTIVITETSPENGER_SAKSBEHANDLER_DEL2,
-                new NavAnsatt.NavGroup(UUID.fromString("df650e66-9590-4c96-8ecb-8efea46f1306"), "0000-GA-Strengt_Fortrolig_Adresse"),
-                new NavAnsatt.NavGroup(UUID.fromString("13e4ed76-6d7f-448f-ba49-41760eed0f30"), "0000-GA-GOSYS_KODE6"),
+                new NavGruppe(UUID.fromString("df650e66-9590-4c96-8ecb-8efea46f1306"), "0000-GA-Strengt_Fortrolig_Adresse"),
+                new NavGruppe(UUID.fromString("13e4ed76-6d7f-448f-ba49-41760eed0f30"), "0000-GA-GOSYS_KODE6"),
                 INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "S777777",
             UUID.fromString("352b0a40-4d13-43e7-8e55-ba6060d6d430"),
@@ -97,12 +103,10 @@ public class AnsatteIndeks {
             "4833",
             List.of(
                 FPSAK_SAKSBEHANDLER, K9_SAKSBEHANDLER, AKTIVITETSPENGER_SAKSBEHANDLER_DEL2,
-                new NavAnsatt.NavGroup(UUID.fromString("bc7fde53-c4c3-4fff-9079-c6440ca5ff5e"), "0000-GA-Fortrolig_Adresse"),
-                new NavAnsatt.NavGroup(UUID.fromString("65715e95-86b5-497d-992a-12389b1a8ff9"), "0000-GA-GOSYS_KODE7"),
+                new NavGruppe(UUID.fromString("bc7fde53-c4c3-4fff-9079-c6440ca5ff5e"), "0000-GA-Fortrolig_Adresse"),
+                new NavGruppe(UUID.fromString("65715e95-86b5-497d-992a-12389b1a8ff9"), "0000-GA-GOSYS_KODE7"),
                 INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "E123456",
             UUID.fromString("98f1a0f3-292e-412c-b84a-d729b6169f2b"),
@@ -113,12 +117,10 @@ public class AnsatteIndeks {
             "4833",
             List.of(
                 FPSAK_SAKSBEHANDLER, K9_SAKSBEHANDLER, AKTIVITETSPENGER_SAKSBEHANDLER_DEL2,
-                new NavAnsatt.NavGroup(UUID.fromString("63b3f84f-1ec5-444b-ad33-2ad2d3495da1"), "0000-GA-Egne_ansatte"),
-                new NavAnsatt.NavGroup(UUID.fromString("00b7a94d-99e6-455c-a497-a3f1a70a698b"), "0000-GA-GOSYS_UTVIDET"),
+                new NavGruppe(UUID.fromString("63b3f84f-1ec5-444b-ad33-2ad2d3495da1"), "0000-GA-Egne_ansatte"),
+                new NavGruppe(UUID.fromString("00b7a94d-99e6-455c-a497-a3f1a70a698b"), "0000-GA-GOSYS_UTVIDET"),
                 INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "B123456",
             UUID.fromString("fb864a55-bc42-4196-aba9-792c78661806"),
@@ -131,9 +133,7 @@ public class AnsatteIndeks {
                 FPSAK_SAKSBEHANDLER, FPSAK_BESLUTTER, K9_SAKSBEHANDLER, K9_BESLUTTER,
                 AKTIVITETSPENGER_SAKSBEHANDLER_DEL2, AKTIVITETSPENGER_BESLUTTER_DEL2,
                 INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "O123456",
             UUID.fromString("d6881997-05d7-4ff2-8ef6-818d8539c434"),
@@ -146,9 +146,7 @@ public class AnsatteIndeks {
                 FPSAK_SAKSBEHANDLER, FPSAK_MANUELT_OVERSTYRER, K9_SAKSBEHANDLER, K9_OVERSTYRER,
                 AKTIVITETSPENGER_SAKSBEHANDLER_DEL2, AKTIVITETSPENGER_OVERSTYRER_DEL2,
                 INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "K123456",
             UUID.fromString("cf70667f-250e-4565-a365-75f07f87fe29"),
@@ -160,11 +158,9 @@ public class AnsatteIndeks {
             List.of(
                 FPSAK_SAKSBEHANDLER, K9_SAKSBEHANDLER, AKTIVITETSPENGER_SAKSBEHANDLER_DEL2,
                 INNTK_8_30, INNTK_8_28,
-                new NavAnsatt.NavGroup(UUID.fromString("6b7c6d2f-ed3d-4d11-bc6d-82cab825a09f"), "0000-GA-PENSJON_KLAGEBEH"),
+                new NavGruppe(UUID.fromString("6b7c6d2f-ed3d-4d11-bc6d-82cab825a09f"), "0000-GA-PENSJON_KLAGEBEH"),
                 INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "V123456",
             UUID.fromString("ba6f0772-b99b-4eb9-857e-7a9e6720d582"),
@@ -176,9 +172,7 @@ public class AnsatteIndeks {
             List.of(
                 FPSAK_VEILEDER, K9_VEILEDER, AKTIVITETSPENGER_VEILEDER,
                 INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "L123456",
             UUID.fromString("4cd710cc-c367-4110-8126-fe495ee11c23"),
@@ -190,9 +184,7 @@ public class AnsatteIndeks {
             List.of(
                 FPSAK_SAKSBEHANDLER, FPSAK_OPPGAVESTYRER, K9_SAKSBEHANDLER, K9_OPPGAVESTYRER,
                 INNTK_8_30, INNTK_8_28, INNTK_FORELDRE, INNTK_PENSJONSGIVENDE, INNTK
-            ),
-            List.of()
-        ),
+            )),
         new NavAnsatt(
             "D123456",
             UUID.fromString("d3b97fcb-8778-4e09-ba7e-f8993d6e26a6"),
@@ -201,9 +193,7 @@ public class AnsatteIndeks {
             "Drifter",
             "daniel.drifter@example.com",
             "2970",
-            List.of(FPSAK_DRIFT, K9_DRIFT, AKTIVITETSPENGER_DRIFT),
-            List.of()
-        ),
+            List.of(FPSAK_DRIFT, K9_DRIFT, AKTIVITETSPENGER_DRIFT)),
         new NavAnsatt(
             "U123456",
             UUID.fromString("b11926c5-9c6f-4d20-a667-0471c4fae717"),
@@ -212,9 +202,7 @@ public class AnsatteIndeks {
             "Ungdomsprogramveileder",
             "une.ungdomsprogramveileder@example.com",
             "4833",
-            List.of(new NavAnsatt.NavGroup(UUID.fromString("c07ba995-a33f-4d0c-b3a8-321e7990cc03"), "0000-CA-ung-programveileder")),
-            List.of()
-        ),
+            List.of(new NavGruppe(UUID.fromString("c07ba995-a33f-4d0c-b3a8-321e7990cc03"), "0000-CA-ung-programveileder"))),
         new NavAnsatt(
             "A111111",
             UUID.fromString("28db24a8-9973-4092-878a-4a73e9010c71"),
@@ -223,9 +211,7 @@ public class AnsatteIndeks {
             "Saksbehandler",
             "akilles.del.1.saksbehandler@example.com",
             "4833",
-            List.of(new NavAnsatt.NavGroup(UUID.fromString("e1bd0c68-0c47-4dd0-ba77-c6e1e46f9d30"), "0000-CA-aktivitetspenger-saksbehandler-del1")),
-            List.of()
-        ),
+            List.of(new NavGruppe(UUID.fromString("e1bd0c68-0c47-4dd0-ba77-c6e1e46f9d30"), "0000-CA-aktivitetspenger-saksbehandler-del1"))),
         new NavAnsatt(
             "B111111",
             UUID.fromString("463c5737-4ff1-4c33-a8ad-c81f248eb593"),
@@ -235,11 +221,9 @@ public class AnsatteIndeks {
             "akhtar.del.1.beslutter@example.com",
             "4833",
             List.of(
-                new NavAnsatt.NavGroup(UUID.fromString("e1bd0c68-0c47-4dd0-ba77-c6e1e46f9d30"), "0000-CA-aktivitetspenger-saksbehandler-del1"),
-                new NavAnsatt.NavGroup(UUID.fromString("4a3cb814-51dc-4587-9215-075e05d29665"), "0000-CA-aktivitetspenger-beslutter-del1")
-            ),
-            List.of()
-        ),
+                new NavGruppe(UUID.fromString("e1bd0c68-0c47-4dd0-ba77-c6e1e46f9d30"), "0000-CA-aktivitetspenger-saksbehandler-del1"),
+                new NavGruppe(UUID.fromString("4a3cb814-51dc-4587-9215-075e05d29665"), "0000-CA-aktivitetspenger-beslutter-del1")
+            )),
         new NavAnsatt(
             "P123456",
             UUID.fromString("3d48bf40-4bfd-48d8-8280-065bf8ced9cd"),
@@ -248,23 +232,36 @@ public class AnsatteIndeks {
             "Point",
             "pip@example.com",
             "2970",
-            List.of(),
-            List.of()
-        )
+            List.of())
     );
 
-    private static final Map<String, NavAnsatt> ansatteByIdent = initByIdent();
-    private static final Map<UUID, NavAnsatt> ansatteById = initById();
+    private static final Map<String, NavAnsatt> ansatteByIdent = ansattByIdent();
+    private static final Map<UUID, NavAnsatt> ansatteById = ansattById();
 
-    private static Map<String, NavAnsatt> initByIdent() {
+    private static final Map<String, NavGruppe> grupperByNavn = gruppeByNavn();
+    private static final Map<UUID, NavGruppe> grupperById = gruppeById();
+
+    private static Map<String, NavAnsatt> ansattByIdent() {
         var map = new ConcurrentHashMap<String, NavAnsatt>();
         ALLE_ANSATTE.forEach(a -> map.put(a.ident().toLowerCase(), a));
         return map;
     }
 
-    private static Map<UUID, NavAnsatt> initById() {
+    private static Map<UUID, NavAnsatt> ansattById() {
         var map = new ConcurrentHashMap<UUID, NavAnsatt>();
         ALLE_ANSATTE.forEach(a -> map.put(a.oid(), a));
+        return map;
+    }
+
+    private static Map<String, NavGruppe> gruppeByNavn() {
+        var map = new ConcurrentHashMap<String, NavGruppe>();
+        ALLE_GRUPPER.forEach(a -> map.put(a.name().toLowerCase(), a));
+        return map;
+    }
+
+    private static Map<UUID, NavGruppe> gruppeById() {
+        var map = new ConcurrentHashMap<UUID, NavGruppe>();
+        ALLE_GRUPPER.forEach(a -> map.put(a.oid(), a));
         return map;
     }
 
@@ -279,4 +276,41 @@ public class AnsatteIndeks {
     public static NavAnsatt findById(UUID id) {
         return ansatteById.get(id);
     }
+
+    public static NavGruppe gruppeByNavn(String navn) {
+        return grupperByNavn.get(navn.toLowerCase());
+    }
+
+    public static NavGruppe gruppeById(UUID id) {
+        return grupperById.get(id);
+    }
+
+    public static void leggTilGrupper(Collection<NavGruppeDto> grupper, boolean erstatt) {
+        if (erstatt) {
+            grupperById.clear();
+            grupperByNavn.clear();
+        }
+        grupper.stream()
+                .filter(g -> erstatt || grupperById.get(g.oid()) == null)
+                .map(g -> new NavGruppe(g.oid(), g.navn()))
+                .forEach(g -> {
+                    grupperById.put(g.oid(), g);
+                    grupperByNavn.put(g.name().toLowerCase(), g);
+            });
+    }
+
+    public static void leggTilAnsatte(Collection<NavAnsattDto> ansatte, boolean erstatt) {
+        if (erstatt) {
+            ansatteById.clear();
+            ansatteByIdent.clear();
+        }
+        ansatte.stream()
+                .filter(a -> erstatt || ansatteByIdent.get(a.ident()) == null)
+                .map(a -> new NavAnsatt(a, a.grupper().stream().map(AnsatteIndeks::gruppeByNavn).toList()))
+                .forEach(a -> {
+                    ansatteById.put(a.oid(), a);
+                    ansatteByIdent.put(a.ident().toLowerCase(), a);
+                });
+    }
+
 }

--- a/domene/src/main/java/no/nav/vtp/ansatt/NavAnsatt.java
+++ b/domene/src/main/java/no/nav/vtp/ansatt/NavAnsatt.java
@@ -3,7 +3,20 @@ package no.nav.vtp.ansatt;
 import java.util.List;
 import java.util.UUID;
 
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavAnsattDto;
+
 public record NavAnsatt(String ident, UUID oid, String displayName, String givenName, String surname, String email,
-                        String streetAddress, List<NavGroup> groups, List<String> enheter) {
-    public record NavGroup(UUID oid, String name) {}
+                        String streetAddress, List<NavGruppe> groups) {
+
+    public NavAnsatt(NavAnsattDto a, List<NavGruppe> groups) {
+        this(a.ident(), a.oid(), a.fornavn() + " " + a.etternavn(), a.fornavn(), a.etternavn(),
+                epost(a), a.enhetId(), groups);
+    }
+
+    private static String epost(NavAnsattDto navAnsattDto) {
+        var fornavn = navAnsattDto.fornavn().toLowerCase().replace(" ", ".");
+        var etternavn = navAnsattDto.etternavn().toLowerCase().replace(" ", ".");
+        return fornavn + "." + etternavn + "@example.com";
+    }
+
 }

--- a/domene/src/main/java/no/nav/vtp/ansatt/NavGruppe.java
+++ b/domene/src/main/java/no/nav/vtp/ansatt/NavGruppe.java
@@ -1,0 +1,6 @@
+package no.nav.vtp.ansatt;
+
+import java.util.UUID;
+
+public record NavGruppe(UUID oid, String name) {
+}

--- a/mocks/ldap-mock/src/main/java/no/nav/foreldrepenger/vtp/ldap/LdapServer.java
+++ b/mocks/ldap-mock/src/main/java/no/nav/foreldrepenger/vtp/ldap/LdapServer.java
@@ -28,6 +28,7 @@ import com.unboundid.ldif.LDIFReader;
 
 import no.nav.vtp.ansatt.AnsatteIndeks;
 import no.nav.vtp.ansatt.NavAnsatt;
+import no.nav.vtp.ansatt.NavGruppe;
 
 public class LdapServer {
     private static final Logger LOG = LoggerFactory.getLogger(LdapServer.class);
@@ -83,7 +84,7 @@ public class LdapServer {
 
     }
 
-    private static List<String> tilMemberOf(List<NavAnsatt.NavGroup> grupper) {
+    private static List<String> tilMemberOf(List<NavGruppe> grupper) {
         return grupper.stream()
                 .map(gruppe -> String.format("CN=%s,OU=AccountGroups,OU=Groups,OU=NAV,OU=BusinessUnits,DC=test,DC=local", gruppe.name()))
                 .toList();

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <sonar.projectKey>navikt_vtp</sonar.projectKey>
 
         <!--    Interne avhengigheter    -->
-        <vtp-kontrakter.version>2.2.0</vtp-kontrakter.version>
+        <vtp-kontrakter.version>2.2.1</vtp-kontrakter.version>
         <fp-kontrakter.version>9.4.37</fp-kontrakter.version>
 
         <!--    Eksterne avhengigheter    -->

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/MockServer.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/MockServer.java
@@ -18,9 +18,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import no.nav.foreldrepenger.util.JacksonObjectMapperTestscenario;
 import no.nav.foreldrepenger.util.KeystoreUtils;
 import no.nav.foreldrepenger.vtp.kafkaembedded.LocalKafkaProducer;
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavAnsattDto;
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavGruppeDto;
 import no.nav.foreldrepenger.vtp.ldap.LdapServer;
+import no.nav.vtp.ansatt.AnsatteIndeks;
 import no.nav.vtp.arbeidsgiverportal.ArbeidsgiverPortalRepository;
 import no.nav.vtp.arbeidsgiverportal.ArbeidsgiverPortalRepositoryImpl;
 import no.nav.vtp.journalpost.JournalRepositoryImpl;
@@ -34,10 +38,8 @@ public class MockServer {
     private static final String TRUSTSTORE_PATH_PROP = "javax.net.ssl.trustStore";
     private static final String KEYSTORE_PASSW_PROP = "no.nav.modig.security.appcert.password";
     private static final String KEYSTORE_PATH_PROP = "no.nav.modig.security.appcert.keystore";
-    public static final String CONTEXT_PATH = System.getProperty("server.context.path", "/rest");
 
     private final int port;
-    private final LdapServer ldapServer;
     private final Server server;
 
     static {
@@ -45,10 +47,10 @@ public class MockServer {
         SLF4JBridgeHandler.install();
     }
 
-    public MockServer() throws Exception {
+    public MockServer() {
         // Sletter kafkalogger så det ikke feiler i forsøk på å lage nye topics
 
-        this.port = Integer.parseInt(System.getProperty("autotest.vtp.port", "8060"));
+        this.port = Integer.parseInt(PropertiesUtils.get("autotest.vtp.port", "8060"));
 
         // Bør denne settes fra ENV_VAR?
         System.setProperty("server.url", "https://localhost:" + getSslPort());
@@ -56,14 +58,28 @@ public class MockServer {
         server = new Server();
         setConnectors(server);
 
-        ldapServer = new LdapServer(new File(KeystoreUtils.getKeystoreFilePath()), KeystoreUtils.getKeyStorePassword().toCharArray());
-
     }
 
     public static void main(String[] args) throws Exception {
         PropertiesUtils.initProperties();
+        initAnsatte();
         var mockServer = new MockServer();
         mockServer.start();
+    }
+
+    public static String getContextPath() {
+        return PropertiesUtils.get("server.context.path", "/rest");
+    }
+
+    public static void initAnsatte() {
+        if (PropertiesUtils.get("vtp.grupper") != null) {
+            var grupper = JacksonObjectMapperTestscenario.listFromJson(PropertiesUtils.get("vtp.grupper"), NavGruppeDto.class);
+            AnsatteIndeks.leggTilGrupper(grupper, true);
+        }
+        if (PropertiesUtils.get("vtp.ansatte") != null) {
+            var ansatte = JacksonObjectMapperTestscenario.listFromJson(PropertiesUtils.get("vtp.ansatte"), NavAnsattDto.class);
+            AnsatteIndeks.leggTilAnsatte(ansatte, true);
+        }
     }
 
     public void start() throws Exception {
@@ -87,14 +103,15 @@ public class MockServer {
                         fagerPortalRepository);
 
         var context = new ServletContextHandler();
-        context.setContextPath(CONTEXT_PATH);
+        context.setContextPath(getContextPath());
         var jerseyServlet = new ServletHolder(new ServletContainer(config));
         jerseyServlet.setInitOrder(1);
         context.addServlet(jerseyServlet, "/*");
         server.setHandler(context);
     }
 
-    private void startLdapServer() {
+    private void startLdapServer() throws Exception {
+        var ldapServer = new LdapServer(new File(KeystoreUtils.getKeystoreFilePath()), KeystoreUtils.getKeyStorePassword().toCharArray());
         var ldapThread = new Thread(ldapServer::start, "LdapServer");
         ldapThread.setDaemon(true);
         ldapThread.start();
@@ -134,9 +151,9 @@ public class MockServer {
         System.setProperty(TRUSTSTORE_PASSW_PROP, KeystoreUtils.getTruststorePassword());
 
         // keystore genererer sertifikat og TLS for innkommende kall. Bruker standard prop hvis definert, ellers faller tilbake på modig props
-        var keystoreProp = System.getProperty("javax.net.ssl.keyStore") != null ? "javax.net.ssl.keyStore" : KEYSTORE_PATH_PROP;
+        var keystoreProp = PropertiesUtils.get("javax.net.ssl.keyStore") != null ? "javax.net.ssl.keyStore" : KEYSTORE_PATH_PROP;
         var keystorePasswProp =
-                System.getProperty("javax.net.ssl.keyStorePassword") != null ? "javax.net.ssl.keyStorePassword" : KEYSTORE_PASSW_PROP;
+                PropertiesUtils.get("javax.net.ssl.keyStorePassword") != null ? "javax.net.ssl.keyStorePassword" : KEYSTORE_PASSW_PROP;
         System.setProperty(keystoreProp, KeystoreUtils.getKeystoreFilePath());
         System.setProperty(keystorePasswProp, KeystoreUtils.getKeyStorePassword());
 
@@ -148,7 +165,7 @@ public class MockServer {
     }
 
     private Integer getSslPort() {
-        return Integer.valueOf(System.getProperty("server.https.port", "" + (port + 3)));
+        return Integer.valueOf(PropertiesUtils.get("server.https.port", "" + (port + 3)));
     }
 
 }

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/PropertiesUtils.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/PropertiesUtils.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -15,33 +16,48 @@ public class PropertiesUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesUtils.class);
 
     private static final String DEV_FILNAVN = "application.properties";
-    private static final String DEV_FILNAVN_LOCAL = "application-local.properties";
 
-    //Brukes av applikasjoner som kjører på root dir
-    public static void initProperties() {
-        initProperties("");
+    private static Properties PROPS;
+
+    private PropertiesUtils() {
     }
 
-    //Brukes av tester som bruker root application.properties
-    public static void initProperties(String propertyDir) {
-        File devFil = Paths.get(propertyDir, DEV_FILNAVN).toFile();
-        loadPropertyFile(devFil);
-        loadPropertyFile(Paths.get(propertyDir, DEV_FILNAVN_LOCAL).toFile());
-        LOGGER.info("PROPERTIES LASTET: ");
-
-    }
-
-    private static void loadPropertyFile(File devFil) {
-        if (devFil.exists()) {
+    public static synchronized void initProperties() {
+        if (PROPS == null) {
             Properties prop = new Properties();
-            try (InputStream inputStream = new FileInputStream(devFil)) {
-                prop.load(inputStream);
-            } catch (IOException e) {
-                LOGGER.error("Kunne ikke finne properties-fil", e);
+            var devFil = Paths.get("", DEV_FILNAVN).toFile();
+            if (devFil.exists()) {
+                loadPropertyFile(prop, devFil);
+            } else {
+                LOGGER.warn("Kunne ikke finne properties-fil: {}", devFil.getAbsolutePath());
             }
-            System.getProperties().putAll(prop);
-        }else {
-            LOGGER.warn("Kunne ikke finne properties-fil: " + devFil.getAbsolutePath());
+            prop.putAll(System.getenv());
+            LOGGER.info("PROPERTIES LASTET: ");
+            PROPS = prop;
         }
     }
+
+    private static void loadPropertyFile(Properties properties, File devFil) {
+        try (InputStream inputStream = new FileInputStream(devFil)) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            LOGGER.error("Kunne ikke finne properties-fil", e);
+        }
+    }
+
+    public static String get(String key) {
+        // Prioritet: System.getProperty, System.getenv, properties-fil
+        if (PROPS == null) {
+            throw new IllegalStateException("Properties not initialized");
+        }
+        return Optional.ofNullable(System.getProperty(key))
+                .or(() -> Optional.ofNullable(PROPS.getProperty(key.toUpperCase().replace(".", "_"))))
+                .orElseGet(() -> PROPS.getProperty(key));
+    }
+
+    public static String get(String key, String defaultValue) {
+        return Optional.ofNullable(get(key)).orElse(defaultValue);
+    }
+
+
 }

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/scenario/TestscenarioRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/api/scenario/TestscenarioRestTjeneste.java
@@ -11,8 +11,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import no.nav.foreldrepenger.vtp.kontrakter.FødselsnummerGenerator;
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavAnsattDto;
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavGruppeDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.PersonDto;
 import no.nav.foreldrepenger.vtp.kontrakter.person.TilordnetIdentDto;
+import no.nav.vtp.ansatt.AnsatteIndeks;
 import no.nav.vtp.person.PersonRepository;
 import no.nav.vtp.person.ident.PersonIdent;
 
@@ -45,6 +48,24 @@ public class TestscenarioRestTjeneste {
                 .map(e -> new TilordnetIdentDto(e.getKey(), e.getValue().fnr(), e.getValue().aktørId()))
                 .toList();
         return Response.status(Response.Status.OK).entity(tilordnedeIdenter).build();
+    }
+
+    @POST
+    @Path("/grupper")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response initialiserGrupper(List<NavGruppeDto> grupper) {
+        AnsatteIndeks.leggTilGrupper(grupper, false);
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    @POST
+    @Path("/ansatte")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response initialiserAnsatte(List<NavAnsattDto> ansatte) {
+        AnsatteIndeks.leggTilAnsatte(ansatte, false);
+        return Response.status(Response.Status.NO_CONTENT).build();
     }
 
     @GET

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/AzureAdRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/AzureAdRestTjeneste.java
@@ -19,8 +19,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import no.nav.foreldrepenger.vtp.server.auth.rest.Issuers;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +39,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import no.nav.foreldrepenger.vtp.server.MockServer;
+import no.nav.foreldrepenger.vtp.server.auth.rest.Issuers;
 import no.nav.foreldrepenger.vtp.server.auth.rest.JsonWebKeyHelper;
 import no.nav.foreldrepenger.vtp.server.auth.rest.Oauth2AccessTokenResponse;
 import no.nav.foreldrepenger.vtp.server.auth.rest.WellKnownResponse;
@@ -153,7 +152,7 @@ public class AzureAdRestTjeneste {
     }
 
     private static String getBaseUrl(HttpServletRequest req) {
-        return req.getScheme() + "://vtp:" + req.getServerPort() + MockServer.CONTEXT_PATH + TJENESTE_PATH;
+        return req.getScheme() + "://vtp:" + req.getServerPort() + MockServer.getContextPath() + TJENESTE_PATH;
     }
 
     @GET

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/MicrosoftGraphApiMock.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/azuread/MicrosoftGraphApiMock.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import no.nav.vtp.ansatt.AnsatteIndeks;
 import no.nav.vtp.ansatt.NavAnsatt;
+import no.nav.vtp.ansatt.NavGruppe;
 
 @Path("/MicrosoftGraphApi")
 public class MicrosoftGraphApiMock {
@@ -142,7 +143,7 @@ public class MicrosoftGraphApiMock {
         return ansatt.groups().stream().map(MicrosoftGraphApiMock::mapTilGroup).toList();
     }
 
-    private static Group mapTilGroup(NavAnsatt.NavGroup group) {
+    private static Group mapTilGroup(NavGruppe group) {
         return new Group(group.oid(), group.name(), group.name());
     }
 

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/idporten/IdportenLoginTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/idporten/IdportenLoginTjeneste.java
@@ -133,6 +133,6 @@ public class IdportenLoginTjeneste {
     }
 
     private static String getBaseUrl(HttpServletRequest req) {
-        return req.getScheme() + "://vtp:" + req.getServerPort() + MockServer.CONTEXT_PATH + TJENESTE_PATH;
+        return req.getScheme() + "://vtp:" + req.getServerPort() + MockServer.getContextPath() + TJENESTE_PATH;
     }
 }

--- a/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/tokenx/TokenxRestTjeneste.java
+++ b/server/src/main/java/no/nav/foreldrepenger/vtp/server/auth/rest/tokenx/TokenxRestTjeneste.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import no.nav.foreldrepenger.vtp.server.MockServer;
+import no.nav.foreldrepenger.vtp.server.PropertiesUtils;
 import no.nav.foreldrepenger.vtp.server.auth.rest.JsonWebKeyHelper;
 
 @Path(TokenxRestTjeneste.TJENESTE_PATH)
@@ -105,7 +106,7 @@ public class TokenxRestTjeneste {
         jwtClaims.setExpirationTimeMinutesInTheFuture(EXPIRE_IN_SECONDS / 60f);
         jwtClaims.setGeneratedJwtId();
         jwtClaims.setIssuedAtToNow();
-        jwtClaims.setClaim("acr", System.getProperty("idporten.acr.scope", "idporten-loa-high"));
+        jwtClaims.setClaim("acr", PropertiesUtils.get("idporten.acr.scope", "idporten-loa-high"));
         jwtClaims.setNotBeforeMinutesInThePast(0F);
 
         var rsaJWK = JsonWebKeyHelper.getJsonWebKey();
@@ -141,7 +142,7 @@ public class TokenxRestTjeneste {
     }
 
     private static String getIssuer(HttpServletRequest req) {
-        return getBaseUrl(req) + MockServer.CONTEXT_PATH + TJENESTE_PATH;
+        return getBaseUrl(req) + MockServer.getContextPath() + TJENESTE_PATH;
     }
 
 }

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/AnsattGruppeEnvTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/AnsattGruppeEnvTest.java
@@ -1,0 +1,44 @@
+package no.nav.foreldrepenger.vtp.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.util.JacksonObjectMapperTestscenario;
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavAnsattDto;
+import no.nav.foreldrepenger.vtp.kontrakter.organisasjon.NavGruppeDto;
+import no.nav.vtp.ansatt.AnsatteIndeks;
+
+/*
+ * Roundtrip test av grupper og ansatte
+ * Data til verdikjede-environment: System out println av "VTP_GRUPPER=\"" + serialized.replace("\"", "\\\"") + "\"" (evt VTP_ANSATTE)
+ */
+class AnsattGruppeEnvTest {
+
+
+    @Test
+    void ansatteOgGrupper() {
+        var gsak = new NavGruppeDto(UUID.fromString("eb211c0d-9ca6-467f-8863-9def2cc06fd3"), "0000-GA-fpsak-saksbehandler");
+        var gveil = new NavGruppeDto(UUID.fromString("edfe14fe-9a34-4ecb-8840-536ac2bc2818"), "0000-GA-fpsak-veileder");
+        var gea = new NavGruppeDto(UUID.fromString("63b3f84f-1ec5-444b-ad33-2ad2d3495da1"), "0000-GA-Egne_ansatte");
+        var saksbehandler = new NavAnsattDto("S123456", UUID.fromString("3c3caafb-a943-4255-aa65-6f29345b7541"),
+                "Sara", "Saksbehandler", "4867", List.of("0000-GA-fpsak-saksbehandler"));
+        var eaveileder = new NavAnsattDto("V123456", UUID.fromString("ba6f0772-b99b-4eb9-857e-7a9e6720d582"),
+                "Vegard", "Veileder", "1900", List.of("0000-GA-fpsak-veileder", "0000-GA-Egne_ansatte"));
+        var aserialized = JacksonObjectMapperTestscenario.writeValueAsString(List.of(saksbehandler, eaveileder));
+        var gserialized = JacksonObjectMapperTestscenario.writeValueAsString(List.of(gsak, gea, gveil));
+        System.setProperty("vtp.grupper", gserialized);
+        System.setProperty("vtp.ansatte", aserialized);
+        PropertiesUtils.initProperties();
+        MockServer.initAnsatte();
+        assertThat(AnsatteIndeks.gruppeByNavn("0000-GA-fpsak-saksbehandler").oid()).isEqualTo(gsak.oid());
+        assertThat(AnsatteIndeks.gruppeByNavn("0000-GA-k9-saksbehandler")).isNull();
+        assertThat(AnsatteIndeks.findByIdent("S123456").oid()).isEqualTo(saksbehandler.oid());
+        assertThat(AnsatteIndeks.findByIdent("S123457")).isNull();
+        assertThat(AnsatteIndeks.findByIdent("V123456").groups())
+                .containsExactlyInAnyOrder(AnsatteIndeks.gruppeByNavn("0000-GA-fpsak-veileder"), AnsatteIndeks.gruppeByNavn("0000-GA-Egne_ansatte"));
+    }
+}

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/HendelseTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/HendelseTest.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.fpmock.server;
+package no.nav.foreldrepenger.vtp.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,9 +19,9 @@ import no.nav.foreldrepenger.vtp.kontrakter.hendelser.DødfødselhendelseDto;
 import no.nav.foreldrepenger.vtp.kontrakter.hendelser.DødshendelseDto;
 import no.nav.foreldrepenger.vtp.kontrakter.hendelser.FødselshendelseDto;
 import no.nav.foreldrepenger.vtp.server.api.pdl.PdlLeesahRestTjeneste;
+import no.nav.person.pdl.leesah.Endringstype;
 import no.nav.vtp.PersonBuilder;
 import no.nav.vtp.person.PersonRepository;
-import no.nav.person.pdl.leesah.Endringstype;
 
 @Disabled
 @ExtendWith(MockitoExtension.class)

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/JournalpostSeraliseringDeseraliseringsTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/JournalpostSeraliseringDeseraliseringsTest.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.fpmock.server;
+package no.nav.foreldrepenger.vtp.server;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/SSLUtilities.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/SSLUtilities.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.fpmock.server;
+package no.nav.foreldrepenger.vtp.server;
 
 /**
  * @author schrepfler

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/SerializationTestBase.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/SerializationTestBase.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.fpmock.server;
+package no.nav.foreldrepenger.vtp.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/api/scenario/PersonMapperTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/api/scenario/PersonMapperTest.java
@@ -1,7 +1,0 @@
-package no.nav.foreldrepenger.vtp.server.api.scenario;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class PersonMapperTest {
-
-}

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/auth/rest/texas/TexasRestTjenesteTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/auth/rest/texas/TexasRestTjenesteTest.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.fpmock.server.auth.rest.texas;
+package no.nav.foreldrepenger.vtp.server.auth.rest.texas;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,10 +17,6 @@ import org.junit.jupiter.api.Test;
 import jakarta.ws.rs.core.Response;
 import no.nav.foreldrepenger.vtp.server.auth.rest.Issuers;
 import no.nav.foreldrepenger.vtp.server.auth.rest.Oauth2AccessTokenResponse;
-import no.nav.foreldrepenger.vtp.server.auth.rest.texas.AuthorizationDetails;
-import no.nav.foreldrepenger.vtp.server.auth.rest.texas.TexasIntrospectRequest;
-import no.nav.foreldrepenger.vtp.server.auth.rest.texas.TexasRestTjeneste;
-import no.nav.foreldrepenger.vtp.server.auth.rest.texas.TexasTokenRequest;
 
 @Disabled("Requires keystore to be configured for signature verification - not suitable for CI environment")
 class TexasRestTjenesteTest {

--- a/server/src/test/java/no/nav/foreldrepenger/vtp/server/auth/rest/tokenx/TokenXTjenesteTest.java
+++ b/server/src/test/java/no/nav/foreldrepenger/vtp/server/auth/rest/tokenx/TokenXTjenesteTest.java
@@ -1,9 +1,7 @@
-package no.nav.foreldrepenger.fpmock.server.auth.rest.tokenx;
+package no.nav.foreldrepenger.vtp.server.auth.rest.tokenx;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
@@ -16,9 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import no.nav.foreldrepenger.vtp.server.auth.rest.tokenx.TokenExchangeResponse;
-import no.nav.foreldrepenger.vtp.server.auth.rest.tokenx.TokenXWellKnownResponse;
-import no.nav.foreldrepenger.vtp.server.auth.rest.tokenx.TokenxRestTjeneste;
+import jakarta.servlet.http.HttpServletRequest;
+import no.nav.foreldrepenger.vtp.server.PropertiesUtils;
 
 @ExtendWith(MockitoExtension.class)
 class TokenXTjenesteTest {
@@ -36,6 +33,7 @@ class TokenXTjenesteTest {
     @Test
     void verifiserRiktigWellKnownEndepunkt() {
         var issuer = "http://vtp:8060/rest/tokenx";
+        PropertiesUtils.initProperties();
         when(req.getScheme()).thenReturn("http");
         when(req.getServerPort()).thenReturn(8060);
         var response = tokenxRestTjeneste.wellKnown(req);

--- a/util/src/main/java/no/nav/foreldrepenger/util/JacksonObjectMapperTestscenario.java
+++ b/util/src/main/java/no/nav/foreldrepenger/util/JacksonObjectMapperTestscenario.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.util;
 
+import java.util.List;
 import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -42,5 +43,9 @@ public class JacksonObjectMapperTestscenario {
 
     public static String writeValueAsString(Object object) {
         return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+    }
+
+    public static <T> List<T> listFromJson(String json, Class<T> clazz) {
+        return MAPPER.readerForListOf(clazz).readValue(json);
     }
 }


### PR DESCRIPTION
Har forbedret PropertiesUtils. 
VTP vil prøve lese VTP_GRUPPER og VTP_ANSATTE fra enviroment og vil da erstatte det som ligger i AnsatteIndex.
Kommer med matchende PR i fp-autotest snart.
Har ikke laget endepunkt for å legge til ekstra ansatte/grupper.