### PR TITLE
TFP-6080 utvider kontrakter med dto for vedtak av ytelse. Skal brukes…

### DIFF
--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelseType.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelseType.java
@@ -1,0 +1,7 @@
+package no.nav.foreldrepenger.vtp.kontrakter.hendelser;
+
+public enum YtelseType {
+
+    PLEIEPENGER_SYKT_BARN,
+
+}

--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelseType.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelseType.java
@@ -1,7 +1,0 @@
-package no.nav.foreldrepenger.vtp.kontrakter.hendelser;
-
-public enum YtelseType {
-
-    PLEIEPENGER_SYKT_BARN,
-
-}

--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelsevedtakDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelsevedtakDto.java
@@ -13,10 +13,10 @@ import java.time.LocalDate;
  * @param tom             siste dag i vedtaksperioden
  * @param utbetalingsgrad utbetalingsgrad i prosent (0–100)
  */
-public record YtelsevedtakDto(
-        String fnr,
-        YtelseType ytelseType,
-        LocalDate fom,
-        LocalDate tom,
-        BigDecimal utbetalingsgrad
-) {}
+public record YtelsevedtakDto(String fnr, YtelseType ytelseType, LocalDate fom, LocalDate tom, BigDecimal utbetalingsgrad) {
+    public enum YtelseType {
+
+        PLEIEPENGER_SYKT_BARN,
+
+    }
+}

--- a/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelsevedtakDto.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/vtp/kontrakter/hendelser/YtelsevedtakDto.java
@@ -1,0 +1,22 @@
+package no.nav.foreldrepenger.vtp.kontrakter.hendelser;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * Representerer et vedtak om en ekstern ytelse som en person har mottatt.
+ * Brukes i autotest for å simulere at en søker har fått innvilget ytelse fra et annet NAV-system.
+ *
+ * @param fnr             fødselsnummer til søker som har fått vedtaket
+ * @param ytelseType      type ytelse
+ * @param fom             første dag i vedtaksperioden
+ * @param tom             siste dag i vedtaksperioden
+ * @param utbetalingsgrad utbetalingsgrad i prosent (0–100)
+ */
+public record YtelsevedtakDto(
+        String fnr,
+        YtelseType ytelseType,
+        LocalDate fom,
+        LocalDate tom,
+        BigDecimal utbetalingsgrad
+) {}


### PR DESCRIPTION
… av autotest for å trigge nytt vedtak om ytelser for søker

Brukes i ny resttjeneste som kommer i neste PR etter at ny kontrakter er releaset