### PR TITLE
Switch to use maintained nv-i18n package

### DIFF
--- a/domene/pom.xml
+++ b/domene/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>kontrakter</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.neovisionaries</groupId>
+            <groupId>uk.co.foundationsedge</groupId>
             <artifactId>nv-i18n</artifactId>
         </dependency>
         <dependency>

--- a/kontrakter/pom.xml
+++ b/kontrakter/pom.xml
@@ -19,9 +19,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.neovisionaries</groupId>
+            <groupId>uk.co.foundationsedge</groupId>
             <artifactId>nv-i18n</artifactId>
-            <version>1.29</version>
+            <version>1.33</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -257,9 +257,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.neovisionaries</groupId>
+                <groupId>uk.co.foundationsedge</groupId>
                 <artifactId>nv-i18n</artifactId>
-                <version>1.29</version>
+                <version>1.33</version>
             </dependency>
 
             <!-- Nav Avhengigheter – kontrakt -->

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -193,7 +193,7 @@
             <artifactId>jul-to-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.neovisionaries</groupId>
+            <groupId>uk.co.foundationsedge</groupId>
             <artifactId>nv-i18n</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
The original nv-i18n is no longer being maintained. Our company app relies on it, and needed newly created entries. A colleague and I have forked and published a new version of it. Due to our reliance on it we will be continuing to maintain it.

Our fork location can be found here https://github.com/foundationsedge/nv-i18n

Apologies, I tried to run this locally to confirm, and it seems there are some maven plugins I can't find. An example is `no.nav.foreldrepenger.felles` perhaps they are internal to you and not externally available?