### PR TITLE
TFP-6363: fjern bruk av READER_TOKEN

### DIFF
--- a/.github/workflows/build-kontrakt.yml
+++ b/.github/workflows/build-kontrakt.yml
@@ -13,14 +13,10 @@ jobs:
     name: Kontrakt
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      pull-requests: read
     uses: navikt/fp-gha-workflows/.github/workflows/build-feature.yml@main  # ratchet:exclude
     with:
       java-version: '25'
       working-directory: ./kontrakter # Sett working directory til kontrakt-mappen
-    secrets: inherit
 
   release-drafter:
     name: Update
@@ -30,4 +26,3 @@ jobs:
       contents: write
       pull-requests: read
     uses: navikt/fp-gha-workflows/.github/workflows/release-drafter.yml@main  # ratchet:exclude
-    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
     with:
       build-image: ${{ github.ref_name == 'master' }} # default: true
       push-image: ${{ github.ref_name == 'master' }} # default: false
-      use-reader: true
     secrets: inherit
 
   build-push-docker-image-ghcr:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,12 @@ jobs:
     name: Build
     permissions:
       contents: read
-      packages: write
+      packages: read
       id-token: write
     uses: navikt/fp-gha-workflows/.github/workflows/build-app-no-db.yml@main # ratchet:exclude
     with:
       build-image: ${{ github.ref_name == 'master' }} # default: true
       push-image: ${{ github.ref_name == 'master' }} # default: false
-    secrets: inherit
 
   build-push-docker-image-ghcr:
     name: Build og push til ghcr

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,4 +16,5 @@ jobs:
       contents: read
       security-events: write
     uses: navikt/fp-gha-workflows/.github/workflows/codeql.yml@main # ratchet:exclude
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,4 @@ jobs:
       contents: read
       security-events: write
     uses: navikt/fp-gha-workflows/.github/workflows/codeql.yml@main # ratchet:exclude
-    with:
-      use-reader: true
     secrets: inherit

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -13,4 +13,3 @@ jobs:
     permissions:
       contents: write
     uses: navikt/fp-gha-workflows/.github/workflows/mvn-dependency-submission.yml@main # ratchet:exclude
-    secrets: inherit

--- a/.github/workflows/release-kontrakt.yml
+++ b/.github/workflows/release-kontrakt.yml
@@ -13,4 +13,3 @@ jobs:
     with:
       release-version: ${{ github.event.release.tag_name }}
       working-directory: ./kontrakter # Sett working directory til kontrakter-mappen
-    secrets: inherit


### PR DESCRIPTION
Fjerner `use-reader: true` slik at bygg/CodeQL bruker den innebygde `GITHUB_TOKEN` i stedet for PAT-en `READER_TOKEN`. Alle Maven-avhengigheter er public og `GITHUB_TOKEN` med `packages: read` resolver hele treet (bevist ved grønne Dependabot-bygg som allerede bruker GITHUB_TOKEN). Del av utfasing av READER_TOKEN i fp-gha-workflows.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>