### PR TITLE
Chore: Returnerer dato for hoveddokumentet

### DIFF
--- a/mocks/saf-mock/src/main/java/no/nav/saf/JournalpostBuilder.java
+++ b/mocks/saf-mock/src/main/java/no/nav/saf/JournalpostBuilder.java
@@ -64,6 +64,7 @@ public class JournalpostBuilder {
             Date mottatt = Date.from( modell.getMottattDato().atZone(ZoneId.systemDefault()).toInstant());
             journalpost.setRelevanteDatoer(List.of(
                     new RelevantDato(mottatt, Datotype.DATO_JOURNALFOERT),
+                    new RelevantDato(mottatt, Datotype.DATO_DOKUMENT),
                     new RelevantDato(mottatt, Datotype.DATO_REGISTRERT)));
         }
         journalpost.setBehandlingstema(modell.getBehandlingTema());


### PR DESCRIPTION
Siden vi har oppdaterer verdikjedetestene våre slik at dokumenter ikke blir lagt direkte inn i k9-sak, men går via fordel og saf-mock, som er slik det fungerer i prod, trenger vi å motta dato for hoveddokumentet fra saf-mocken.