### PR TITLE
TSFF-2935 endrer vedtaksreferanse i spøkelse mock

### DIFF
--- a/mocks/spokelse-mock/src/main/java/no/nav/tjeneste/virksomhet/spokelse/rest/PersonTilSykepengeVedtakMapper.java
+++ b/mocks/spokelse-mock/src/main/java/no/nav/tjeneste/virksomhet/spokelse/rest/PersonTilSykepengeVedtakMapper.java
@@ -39,7 +39,7 @@ public class PersonTilSykepengeVedtakMapper {
         // til at konsumenter kan skille vedtak fra hverandre. Bruker fom som grunnlag for determinisme.
         var vedtaksreferanse = "SPOKELSE-" + ytelse.fom();
         var vedtattTidspunkt = ytelse.fom() != null ? ytelse.fom().atStartOfDay() : null;
-        return new SykepengeVedtak(vedtaksreferanse, List.of(utbetaling), vedtattTidspunkt);
+        return new SykepengeVedtak(vedtaksreferanse.replace("-", ""), List.of(utbetaling), vedtattTidspunkt);
     }
 
     private static java.math.BigDecimal tilGrad(Ytelse ytelse) {

--- a/mocks/spokelse-mock/src/main/java/no/nav/tjeneste/virksomhet/spokelse/rest/PersonTilSykepengeVedtakMapper.java
+++ b/mocks/spokelse-mock/src/main/java/no/nav/tjeneste/virksomhet/spokelse/rest/PersonTilSykepengeVedtakMapper.java
@@ -37,9 +37,9 @@ public class PersonTilSykepengeVedtakMapper {
         var utbetaling = new SykepengeUtbetaling(ytelse.fom(), ytelse.tom(), tilGrad(ytelse));
         // Vedtaksreferanse har ingen semantisk betydning for testdata - trenger bare å være unik nok
         // til at konsumenter kan skille vedtak fra hverandre. Bruker fom som grunnlag for determinisme.
-        var vedtaksreferanse = "SPOKELSE-" + ytelse.fom();
+        var vedtaksreferanse = ("SPOKELSE-" + ytelse.fom()).replace("-", "");
         var vedtattTidspunkt = ytelse.fom() != null ? ytelse.fom().atStartOfDay() : null;
-        return new SykepengeVedtak(vedtaksreferanse.replace("-", ""), List.of(utbetaling), vedtattTidspunkt);
+        return new SykepengeVedtak(vedtaksreferanse, List.of(utbetaling), vedtattTidspunkt);
     }
 
     private static java.math.BigDecimal tilGrad(Ytelse ytelse) {

--- a/mocks/spokelse-mock/src/main/java/no/nav/tjeneste/virksomhet/spokelse/rest/PersonTilSykepengeVedtakMapper.java
+++ b/mocks/spokelse-mock/src/main/java/no/nav/tjeneste/virksomhet/spokelse/rest/PersonTilSykepengeVedtakMapper.java
@@ -37,7 +37,7 @@ public class PersonTilSykepengeVedtakMapper {
         var utbetaling = new SykepengeUtbetaling(ytelse.fom(), ytelse.tom(), tilGrad(ytelse));
         // Vedtaksreferanse har ingen semantisk betydning for testdata - trenger bare å være unik nok
         // til at konsumenter kan skille vedtak fra hverandre. Bruker fom som grunnlag for determinisme.
-        var vedtaksreferanse = ("SPOKELSE-" + ytelse.fom()).replace("-", "");
+        var vedtaksreferanse = ("SPOKELSE" + ytelse.fom()).replace("-", "");
         var vedtattTidspunkt = ytelse.fom() != null ? ytelse.fom().atStartOfDay() : null;
         return new SykepengeVedtak(vedtaksreferanse, List.of(utbetaling), vedtattTidspunkt);
     }


### PR DESCRIPTION
Skriver om k9-verdikjede for å matche ny v2-kontrakt for testscenario og oppdaget at noen tester feiler på validering av vedtaksreferansen. Fjerner "-" fra vedtaksreferanse da jeg har forstått det slik at denne ikke er så viktig uansett