### PR TITLE
Chore: dependabot sjekker journalhendelse-avro-versjon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,6 @@ updates:
       exclude:
         - "no.nav.*"
     open-pull-requests-limit: 20
-    ignore:
-      - dependency-name: "no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas"
     groups:
       prod-deps:
         dependency-type: "production"


### PR DESCRIPTION
Vi lagger en del med 1.1.6 - nåværende er 1.1.11 